### PR TITLE
Add configurable recurring transaction forecasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cargo install budget_tracker_tui
 ## Features
 
 - Add, edit, delete, filter, and sort income and expense transactions
-- Recurring transactions, from daily to yearly, generated automatically up to today
+- Recurring transactions, from daily to yearly, generated automatically up to today or a forecast horizon you set
 - Hierarchical categories and subcategories, editable in-app, with optional fuzzy search
 - Monthly and category summaries with interactive charts
 - Monthly target budget plus optional per-category budgets, tracked in a dedicated budget view

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -42,6 +42,12 @@ Select a transaction and press `r` to make it recurring. Available frequencies:
 
 Occurrences are generated automatically from the start date up to today, and an optional end date stops the series. Generated occurrences stay linked to their source transaction. Edit or delete the source to affect the series.
 
+### Forecasting ahead
+
+By default generation stops at today. Set *Forecast Months Ahead* in settings to project occurrences further out, up to 60 months. Forecast rows appear dimmed in the transaction table, the table title shows the active horizon, and the summary and budget views pick up the projected months so you can see where the year is heading.
+
+Forecast occurrences are derived in memory like every other generated occurrence: nothing extra is written to the database, an end date still cuts the series off, and setting the horizon back to `0` returns to today-only generation.
+
 ## Summary views
 
 **Monthly summary (`s`)** shows income, expenses, and net per month with an interactive chart. `↑`/`↓` move between months, `←`/`→` (or `[`/`]`) move between years. `m` toggles a multi-month line chart, and `c` toggles cumulative mode, which also draws the target budget line from settings.
@@ -77,6 +83,10 @@ Press `o` to open settings. The menu is grouped into sections:
 **Transaction View**
 
 - *Hourly Rate*: optionally enter your hourly earning rate; a *Show Costs in Hours* toggle then appears that displays amounts as hours worked.
+
+**Recurring Transactions**
+
+- *Forecast Months Ahead*: projects recurring occurrences this many months past today (0-60). `0` stops at today.
 
 **Input Preferences**
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -261,6 +261,16 @@ impl App {
         }
     }
 
+    fn insert_char_at_settings_cursor(&mut self, idx: usize, c: char) {
+        let item = &mut self.settings_state.items[idx];
+        if self.settings_state.edit_cursor >= item.value.len() {
+            item.value.push(c);
+        } else {
+            item.value.insert(self.settings_state.edit_cursor, c);
+        }
+        self.settings_state.edit_cursor += c.len_utf8();
+    }
+
     pub(crate) fn insert_char_settings(&mut self, c: char) {
         let idx = self.settings_state.selected_index;
         if idx >= self.settings_state.items.len() {
@@ -276,13 +286,12 @@ impl App {
             crate::app::settings_types::SettingType::Number => {
                 if crate::validation::validate_amount_char(&self.settings_state.items[idx].value, c)
                 {
-                    let item = &mut self.settings_state.items[idx];
-                    if self.settings_state.edit_cursor >= item.value.len() {
-                        item.value.push(c);
-                    } else {
-                        item.value.insert(self.settings_state.edit_cursor, c);
-                    }
-                    self.settings_state.edit_cursor += c.len_utf8();
+                    self.insert_char_at_settings_cursor(idx, c);
+                }
+            }
+            crate::app::settings_types::SettingType::Integer => {
+                if c.is_ascii_digit() {
+                    self.insert_char_at_settings_cursor(idx, c);
                 }
             }
             crate::app::settings_types::SettingType::Path => {
@@ -322,7 +331,8 @@ impl App {
 
         match setting_type {
             crate::app::settings_types::SettingType::SectionHeader => {}
-            crate::app::settings_types::SettingType::Number => {
+            crate::app::settings_types::SettingType::Number
+            | crate::app::settings_types::SettingType::Integer => {
                 let cursor = self.settings_state.edit_cursor;
                 let item = &mut self.settings_state.items[idx];
                 if cursor > 0 && !item.value.is_empty() {

--- a/src/app/recurring.rs
+++ b/src/app/recurring.rs
@@ -17,9 +17,10 @@ impl App {
             .cloned()
             .collect();
 
-        // Generate new recurring transactions up to today
+        // Generate up to today, or further out when a forecast horizon is configured.
         let today = chrono::Local::now().date_naive();
-        let generated = generate_recurring_transactions(&recurring_transactions, today);
+        let horizon = crate::validation::add_months(today, self.recurring_forecast_months as i32);
+        let generated = generate_recurring_transactions(&recurring_transactions, horizon);
 
         // Add generated transactions to the main list
         self.transactions.extend(generated);

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -97,6 +97,21 @@ impl App {
             );
         }
 
+        // --- Recurring Transactions Section ---
+        self.settings_state.add_header("Recurring Transactions");
+
+        let forecast_val = self.recurring_forecast_months.to_string();
+        self.settings_state.add_setting(
+            SettingKey::RecurringForecastMonths,
+            "Forecast Months Ahead",
+            forecast_val,
+            SettingType::Integer,
+            &format!(
+                "Project recurring occurrences this many months past today (0-{}). 0 stops at today.",
+                crate::recurring::MAX_FORECAST_MONTHS
+            ),
+        );
+
         // --- Input Preferences Section ---
         self.settings_state.add_header("Input Preferences");
 
@@ -164,6 +179,7 @@ impl App {
         let mut new_database_path_str = String::new();
         let mut target_budget_str = String::new();
         let mut hourly_rate_str = String::new();
+        let mut forecast_months_str = String::new();
         let mut show_hours_val = None;
         let mut fuzzy_search_val = None;
         let mut hide_help_bar_val = None;
@@ -176,6 +192,12 @@ impl App {
         }
         if let Some(val) = self.settings_state.get_value(SettingKey::HourlyRate) {
             hourly_rate_str = val.trim().to_string();
+        }
+        if let Some(val) = self
+            .settings_state
+            .get_value(SettingKey::RecurringForecastMonths)
+        {
+            forecast_months_str = val.trim().to_string();
         }
         if let Some(val) = self.settings_state.get_value(SettingKey::ShowHours) {
             show_hours_val = Some(val.to_lowercase().contains("yes"));
@@ -208,6 +230,25 @@ impl App {
                 Ok(val) => Some(val),
                 Err(msg) => {
                     self.set_status_message(format!("Error: Hourly rate - {}", msg), None);
+                    return;
+                }
+            }
+        };
+
+        // Validate Recurring Forecast Horizon
+        let forecast_months = if forecast_months_str.is_empty() {
+            0
+        } else {
+            match forecast_months_str.parse::<u32>() {
+                Ok(val) if val <= crate::recurring::MAX_FORECAST_MONTHS => val,
+                _ => {
+                    self.set_status_message(
+                        format!(
+                            "Error: Forecast months must be a whole number between 0 and {}.",
+                            crate::recurring::MAX_FORECAST_MONTHS
+                        ),
+                        None,
+                    );
                     return;
                 }
             }
@@ -251,11 +292,15 @@ impl App {
             show_hours: show_hours_val,
             fuzzy_search_mode: fuzzy_search_val,
             hide_help_bar: hide_help_bar_val,
+            recurring_forecast_months: Some(forecast_months),
         };
         if let Err(e) = save_settings(&settings) {
             self.set_status_message(format!("Error saving config file: {}", e), None);
             return;
         }
+
+        // Set before reloading so occurrences are re-derived against the new horizon.
+        self.recurring_forecast_months = forecast_months;
 
         // Point at the new database and reload everything from it.
         self.database_path = new_database_path.clone();

--- a/src/app/settings_types.rs
+++ b/src/app/settings_types.rs
@@ -3,6 +3,7 @@ pub enum SettingType {
     SectionHeader,
     Path,
     Number,
+    Integer,
     Toggle,
     Action,
 }
@@ -21,6 +22,7 @@ pub enum SettingKey {
     ShowHours,
     FuzzySearch,
     HideHelpBar,
+    RecurringForecastMonths,
 }
 
 #[derive(Debug, Clone)]

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -137,6 +137,8 @@ pub struct App {
     pub(crate) recurring_settings_fields: [String; 3], // [is_recurring, frequency, end_date]
     pub(crate) current_recurring_field: usize,
     pub(crate) recurring_transaction_index: Option<usize>,
+    // Months past today that recurring occurrences are projected; 0 stops at today.
+    pub(crate) recurring_forecast_months: u32,
     // Import/Export path prompt state (shared by ImportTransactions/ExportTransactions modes)
     pub(crate) io_path_input: String,
     pub(crate) io_path_cursor: usize,
@@ -325,6 +327,10 @@ impl App {
             recurring_settings_fields: Default::default(),
             current_recurring_field: 0,
             recurring_transaction_index: None,
+            recurring_forecast_months: loaded_settings
+                .recurring_forecast_months
+                .unwrap_or(0)
+                .min(crate::recurring::MAX_FORECAST_MONTHS),
             io_path_input: String::new(),
             io_path_cursor: 0,
             previous_mode: None,
@@ -344,7 +350,7 @@ impl App {
             app.table_state.select(Some(0));
         }
 
-        // Generate recurring transactions up to today
+        // Generate recurring transactions up to today (or the configured forecast horizon)
         app.generate_recurring_transactions();
 
         app

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ pub(crate) struct AppSettings {
     pub(crate) show_hours: Option<bool>,
     pub(crate) fuzzy_search_mode: Option<bool>,
     pub(crate) hide_help_bar: Option<bool>,
+    pub(crate) recurring_forecast_months: Option<u32>,
 }
 
 fn get_config_file_path() -> Result<PathBuf, Error> {

--- a/src/recurring.rs
+++ b/src/recurring.rs
@@ -5,6 +5,10 @@
 use crate::model::{RecurrenceFrequency, Transaction};
 use chrono::{Datelike, Duration, NaiveDate};
 
+/// Upper bound on how far ahead recurring occurrences may be projected. Daily series generate
+/// one row per day, so an unbounded horizon would balloon the in-memory transaction list.
+pub const MAX_FORECAST_MONTHS: u32 = 60;
+
 /// Generates recurring transaction instances from a list of recurring transactions
 /// up to a specified date.
 ///

--- a/src/ui/transaction_table.rs
+++ b/src/ui/transaction_table.rs
@@ -56,6 +56,8 @@ pub fn render_transaction_table(f: &mut Frame, app: &mut App, area: Rect) {
         .height(1)
         .bottom_margin(1);
 
+    // Forecast occurrences are dimmed so they read as projections, not settled transactions.
+    let today = chrono::Local::now().date_naive();
     let rows = app.filtered_indices.iter().map(|&original_index| {
         if original_index >= app.transactions.len() {
             return Row::new(vec![Cell::from("Error: Invalid Index").fg(Color::Red)])
@@ -94,7 +96,12 @@ pub fn render_transaction_table(f: &mut Frame, app: &mut App, area: Rect) {
             Cell::from(Line::from(amount_cell_text).alignment(Alignment::Right))
                 .style(amount_style),
         ];
-        Row::new(cells).height(1).bottom_margin(0)
+        let row = Row::new(cells).height(1).bottom_margin(0);
+        if tx.is_generated_from_recurring && tx.date > today {
+            row.style(Style::default().add_modifier(Modifier::DIM))
+        } else {
+            row
+        }
     });
 
     let is_filtered = app.filtered_indices.len() != app.transactions.len();
@@ -112,6 +119,12 @@ pub fn render_transaction_table(f: &mut Frame, app: &mut App, area: Rect) {
             "Transactions",
             Style::default().add_modifier(Modifier::BOLD),
         ));
+        if app.recurring_forecast_months > 0 {
+            spans.push(Span::styled(
+                format!(" (Forecast +{}mo)", app.recurring_forecast_months),
+                Style::default().fg(Color::Cyan),
+            ));
+        }
         Line::from(spans)
     };
     let table = Table::new(


### PR DESCRIPTION
Right now recurring transactions only generate up to today. This adds a Forecast Months Ahead setting (Settings → Recurring Transactions) so you can project them further out, handy for seeing what the next few months look like before they happen.

- Defaults to 0, which is exactly the current behaviour. Capped at 60 months since daily series generate a row per day.
- Forecast rows are still generated in memory like every other recurring occurrence. Nothing new gets written to the DB, and end dates still cut a series off early.
- Future rows show dimmed in the table, and the title shows the active horizon, so projections don't read as settled transactions.
- Summary and budget views pick up the projected months automatically.

Docs updated in docs/user-guide.md.