### PR TITLE
Automate tagged releases and crate publishing

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -1,0 +1,37 @@
+# Releasing
+
+A release starts with a tag push and ends with you publishing the draft. Two workflows handle everything in between.
+
+## Setup
+
+The crates.io publish needs an API token with the `publish-update` scope, created at <https://crates.io/settings/tokens> and stored as the repository secret `CARGO_REGISTRY_TOKEN` under Settings > Secrets and variables > Actions.
+
+## Steps
+
+1. Bump `version` in `Cargo.toml`, both under `[package]` and under `[package.metadata.bundle]`, and merge to `main`.
+2. Tag the release and push the tag:
+
+   ```bash
+   git tag -s vX.Y.Z -m "vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+3. `release.yml` checks the tag against both versions in `Cargo.toml`, runs formatting, Clippy, and the tests, then builds the binaries and opens a draft release with them attached:
+
+   | Asset | Platform |
+   | --- | --- |
+   | `Budget_Tracker_linux` | Linux x86_64 |
+   | `Budget_Tracker_MacOS` | macOS arm64 |
+   | `Budget_Tracker.exe` | Windows x86_64 |
+
+4. Edit the draft. The title and the generated changelog are already filled in; add the installer, the summary, and the screenshot.
+5. Publish the release. `publish-crate.yml` then checks out the tag and runs `cargo publish`.
+
+The in-app update check reads the latest published release, so a draft stays invisible to users until step 5.
+
+## Notes
+
+- Re-running the release workflow on an existing release replaces the binaries and leaves the title, body, and any manually uploaded files alone.
+- To abandon a release before publishing, delete the draft and delete the tag with `git push --delete origin <tag>`. Nothing has reached crates.io yet.
+- If `cargo publish` fails, run it again from Actions > Publish to crates.io > Run workflow, passing the tag.
+- A release marked as a pre-release gets a draft and binaries, but is not published to crates.io.

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -1,0 +1,59 @@
+name: Publish to crates.io
+
+on:
+  release:
+    types: [published]
+  # Manual fallback if the release-triggered run fails.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: publish-crate-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: cargo publish
+    # Pre-releases are not published to crates.io.
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the released tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check tag matches Cargo.toml version
+        env:
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          tag_version="${TAG#v}"
+          pkg_version=$(awk -F'"' '/^\[/{s=$0} s=="[package]" && /^version = /{print $2; exit}' Cargo.toml)
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "::error::Tag $TAG does not match [package] version $pkg_version in Cargo.toml."
+            exit 1
+          fi
+          echo "Publishing budget_tracker_tui $pkg_version"
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,178 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+  BIN_NAME: Budget_Tracker
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: Verify tag & test
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy, rustfmt
+
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check tag matches Cargo.toml version
+        id: version
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          pkg_version=$(awk -F'"' '/^\[/{s=$0} s=="[package]" && /^version = /{print $2; exit}' Cargo.toml)
+          bundle_version=$(awk -F'"' '/^\[/{s=$0} s=="[package.metadata.bundle]" && /^version = /{print $2; exit}' Cargo.toml)
+
+          echo "tag:    $tag_version"
+          echo "package: $pkg_version"
+          echo "bundle:  $bundle_version"
+
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match [package] version $pkg_version in Cargo.toml."
+            exit 1
+          fi
+          if [ "$tag_version" != "$bundle_version" ]; then
+            echo "::error::Tag $GITHUB_REF_NAME does not match [package.metadata.bundle] version $bundle_version in Cargo.toml."
+            exit 1
+          fi
+          echo "version=$tag_version" >> "$GITHUB_OUTPUT"
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Run Clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Run tests
+        run: cargo test --verbose
+
+      - name: Verify the crate packages cleanly for crates.io
+        run: cargo publish --dry-run --locked
+
+  build:
+    name: Build ${{ matrix.asset_name }}
+    needs: verify
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # 22.04 links against an older glibc, which widens the range of
+          # distributions the binary will run on.
+          - os: ubuntu-22.04
+            asset_name: Budget_Tracker_linux
+            built_name: Budget_Tracker
+          # macos-latest runners are Apple Silicon.
+          - os: macos-latest
+            asset_name: Budget_Tracker_MacOS
+            built_name: Budget_Tracker
+          - os: windows-latest
+            asset_name: Budget_Tracker.exe
+            built_name: Budget_Tracker.exe
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Cache Cargo dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: cargo build --release --locked
+
+      - name: Stage asset under its release name
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp "target/release/${{ matrix.built_name }}" "dist/${{ matrix.asset_name }}"
+          ls -l dist
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset_name }}
+          path: dist/${{ matrix.asset_name }}
+          if-no-files-found: error
+          retention-days: 7
+
+  draft_release:
+    name: Create draft release
+    needs: [verify, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: List assets
+        run: ls -l dist
+
+      - name: Create or update the draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          VERSION: ${{ needs.verify.outputs.version }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; replacing the binaries only."
+            gh release upload "$TAG" dist/* --clobber
+            exit 0
+          fi
+
+          gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+            -f tag_name="$TAG" \
+            -q .body > generated_notes.md
+
+          {
+            echo "# Budget Tracker TUI $VERSION"
+            echo
+            cat generated_notes.md
+            echo
+            cat <<'EOF'
+
+          To update/install easily without downloading anything you can use cargo! (**If you are not using the installer below**)
+          ```bash
+          cargo install budget_tracker_tui
+          ```
+
+          ### TLDR:
+
+          <!-- Add the summary, screenshot, and installer before publishing, then delete this line. -->
+          EOF
+          } > release_notes.md
+
+          gh release create "$TAG" \
+            --draft \
+            --verify-tag \
+            --title "Budget Tracker $VERSION" \
+            --notes-file release_notes.md \
+            dist/*
+
+          echo "Draft release created: $(gh release view "$TAG" --json url -q .url)"


### PR DESCRIPTION
Add release workflows for verification, cross-platform builds, draft GitHub releases, and crates.io publishing, along with release documentation.