### PR TITLE
Exit after opening update link and report failures

### DIFF
--- a/src/events/runner.rs
+++ b/src/events/runner.rs
@@ -107,10 +107,19 @@ fn update(app: &mut App, key_event: KeyEvent) {
         if key_event.kind == KeyEventKind::Press {
             match key_event.code {
                 KeyCode::Enter | KeyCode::Char('o') => {
-                    let _ = crate::app::util::open_url(
+                    let opened = crate::app::util::open_url(
                         "https://github.com/Feromond/budget_tracker_tui/releases",
                     );
                     app.show_update_popup = false;
+                    if opened {
+                        // Close the app so the old and new versions are not run side by side.
+                        app.quit();
+                    } else {
+                        app.set_status_message(
+                            "Could not open browser. Visit github.com/Feromond/budget_tracker_tui/releases",
+                            Some(chrono::Duration::seconds(5)),
+                        );
+                    }
                 }
                 _ => {
                     app.show_update_popup = false;

--- a/src/ui/update_popup.rs
+++ b/src/ui/update_popup.rs
@@ -26,7 +26,7 @@ pub fn render_update_popup(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(block, popup_area);
 
     let text = format!(
-        "\n\nA new version ({}) is available!\n\nVisit GitHub releases to download.\n\nPress <Enter> or 'o' to open link.\nPress any other key to close.",
+        "\n\nA new version ({}) is available!\n\nVisit GitHub releases to download.\n\nPress <Enter> or 'o' to open the link and exit.\nPress any other key to close.",
         version
     );
 


### PR DESCRIPTION
Ensure the app closes after choosing to go update the app. This is to prevent accidental cases where the user has the old version open at the same time as a new app version.