### PR TITLE
Fix Amount To filter, guard exports against the database, format amounts as decimals

### DIFF
--- a/src/app/category_manager.rs
+++ b/src/app/category_manager.rs
@@ -320,6 +320,23 @@ impl App {
         });
         let editing_category_id = self.editing_category_id;
 
+        // The schema's UNIQUE constraint compares case-sensitively, but rename and delete
+        // propagate to transactions with LOWER(), so a case-variant pair would let an edit to
+        // one record rewrite the other's transactions. Reject the duplicate here instead.
+        let duplicate = self.category_records.iter().any(|record| {
+            Some(record.id) != editing_category_id
+                && record.transaction_type == draft.transaction_type
+                && record.category.eq_ignore_ascii_case(&draft.category)
+                && record.subcategory.eq_ignore_ascii_case(&draft.subcategory)
+        });
+        if duplicate {
+            self.set_status_message(
+                "Error: that category already exists (names are matched without case).",
+                None,
+            );
+            return;
+        }
+
         if draft.transaction_type == TransactionType::Income
             && draft.target_budget.is_none()
             && let Some(old_record) = existing_record.as_ref()

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -67,8 +67,8 @@ impl App {
                 let input_type = match idx {
                     0 | 1 => InputType::Date,
                     2 => InputType::Text, // Description
-                    6 | 7 => InputType::Amount,
-                    _ => return None, // Category(3), Subcategory(4), Type(5) are selections/toggles
+                    7 | 8 => InputType::Amount,
+                    _ => return None, // Category(3), Subcategory(4), Type(5), Recurring(6) are selections/toggles
                 };
                 Some((
                     &mut self.advanced_filter_fields[idx],

--- a/src/app/transaction_io.rs
+++ b/src/app/transaction_io.rs
@@ -2,7 +2,7 @@ use super::state::{App, AppMode};
 use crate::csv_io::{load_transactions, save_transactions};
 use crate::db::transaction_store::TransactionStore;
 use chrono::Duration;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 impl App {
     pub(crate) fn open_transaction_io(&mut self, mode: AppMode) {
@@ -84,6 +84,29 @@ impl App {
         );
     }
 
+    /// Resolve a path for comparison. The destination usually does not exist yet, so fall back to
+    /// canonicalizing the parent so relative paths and symlinked directories still compare equal.
+    fn resolve_io_path(path: &Path) -> PathBuf {
+        if let Ok(canonical) = path.canonicalize() {
+            return canonical;
+        }
+
+        let absolute = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            match std::env::current_dir() {
+                Ok(cwd) => cwd.join(path),
+                Err(_) => path.to_path_buf(),
+            }
+        };
+
+        let resolved = match (absolute.parent(), absolute.file_name()) {
+            (Some(parent), Some(name)) => parent.canonicalize().map(|p| p.join(name)).ok(),
+            _ => None,
+        };
+        resolved.unwrap_or(absolute)
+    }
+
     pub(crate) fn export_transactions(&mut self) {
         let path_str = crate::validation::strip_path_quotes(&self.io_path_input);
         if path_str.trim().is_empty() {
@@ -91,6 +114,15 @@ impl App {
             return;
         }
         let path = PathBuf::from(&path_str);
+
+        // save_transactions truncates whatever it opens, so refuse the live database outright.
+        if Self::resolve_io_path(&path) == Self::resolve_io_path(&self.database_path) {
+            self.set_status_message(
+                "Error: that is the active database file. Choose a different export destination.",
+                None,
+            );
+            return;
+        }
 
         // Export the materialized view (real rows plus generated occurrences) for a complete CSV.
         match save_transactions(&self.transactions, &path) {

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -1,14 +1,14 @@
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::Color;
-use rust_decimal::Decimal;
-use rust_decimal::prelude::*;
+use rust_decimal::{Decimal, RoundingStrategy};
 
 pub fn format_amount(amount: &Decimal) -> String {
-    let value = amount.to_f64().unwrap_or(0.0);
-    let s = format!("{:.2}", value.abs());
-    let parts: Vec<&str> = s.split('.').collect();
-    let int_part = parts[0];
-    let frac_part = parts[1];
+    // Format straight off the Decimal: going through f64 first would round monetary values
+    // against their binary approximation rather than their stored decimal digits. Half-away-from-
+    // zero is the usual currency convention, where round_dp alone would round half to even.
+    let rounded = amount.round_dp_with_strategy(2, RoundingStrategy::MidpointAwayFromZero);
+    let s = format!("{:.2}", rounded.abs());
+    let (int_part, frac_part) = s.split_once('.').unwrap_or((s.as_str(), "00"));
 
     let mut formatted_int = String::new();
     for (count, c) in int_part.chars().rev().enumerate() {
@@ -19,7 +19,11 @@ pub fn format_amount(amount: &Decimal) -> String {
     }
 
     let formatted_int: String = formatted_int.chars().rev().collect();
-    let sign = if value < 0.0 { "-" } else { "" };
+    let sign = if rounded.is_sign_negative() && !rounded.is_zero() {
+        "-"
+    } else {
+        ""
+    };
 
     format!("{}{}.{}", sign, formatted_int, frac_part)
 }
@@ -28,7 +32,7 @@ pub fn format_hours(amount: &Decimal, hourly_rate: Option<Decimal>) -> String {
     if let Some(rate) = hourly_rate
         && rate > Decimal::ZERO
     {
-        let hours = (amount / rate).to_f64().unwrap_or(0.0);
+        let hours = (amount / rate).round_dp(1);
         return format!("{:.1}h", hours);
     }
     format_amount(amount)


### PR DESCRIPTION
Ran a review over the project and fixed the findings that were actually worth acting on.

- **Amount To filter did nothing.** The advanced filter routed input with the wrong field
  indices (`6 | 7` instead of `7 | 8`), so Amount To ignored all typing and the Recurring
  toggle accepted digits, which silently turned the recurring filter off.
- **Export could overwrite the database.** `save_transactions` does a bare `File::create`,
  so exporting to the DB path truncated it. Now blocked, including via relative paths and
  symlinks.
- **`Housing` and `housing` could both exist.** The schema's UNIQUE is case-sensitive but
  rename/delete propagate with `LOWER()`, so editing one rewrote the other's transactions.
  The category editor now rejects the duplicate.
- **Amounts were formatted through f64.** `format_amount` now rounds and signs off the
  `Decimal` directly.

One behavior change worth knowing: rounding is half-away-from-zero now (the usual currency
convention), so `1.005` displays as `1.01` where it used to show `1.00`.

Skipped as not worth the churn: terminal restore on panic, UTF-8 cursor boundaries in the
settings path field, and transactional first-run category seeding.