### PR TITLE
Refactor form fields around typed field sets

### DIFF
--- a/src/app/add_edit.rs
+++ b/src/app/add_edit.rs
@@ -1,4 +1,5 @@
 use super::state::App;
+use crate::app::fields::{AddEditField, FieldSet};
 use crate::db::transaction_store::TransactionStore;
 use crate::model::TransactionType;
 use crate::model::{DATE_FORMAT, TransactionDraft};
@@ -57,18 +58,16 @@ impl App {
     pub(crate) fn start_adding(&mut self) {
         self.mode = crate::app::state::AppMode::Adding;
         self.editing_index = None;
-        self.current_add_edit_field = 0;
         self.add_edit_fields = Default::default();
         let today = chrono::Local::now().date_naive();
-        self.add_edit_fields[0] = today.format(DATE_FORMAT).to_string();
-        self.add_edit_fields[3] = "Expense".to_string();
-        self.add_edit_cursor = self.add_edit_fields[0].len();
+        self.add_edit_fields[AddEditField::Date] = today.format(DATE_FORMAT).to_string();
+        self.add_edit_fields[AddEditField::TransactionType] = "Expense".to_string();
+        self.add_edit_cursor = self.add_edit_fields[AddEditField::Date].len();
         self.clear_status_message();
     }
     pub(crate) fn exit_adding(&mut self, cancelled: bool) {
         self.mode = crate::app::state::AppMode::Normal;
         self.editing_index = None;
-        self.current_add_edit_field = 0;
         self.add_edit_fields = Default::default();
         if cancelled {
             self.set_status_message("Add transaction cancelled.", Some(Duration::seconds(3)));
@@ -76,12 +75,15 @@ impl App {
     }
     pub(crate) fn add_transaction(&mut self) {
         // Parse and validate all fields for a new transaction.
-        let date_res = NaiveDate::parse_from_str(&self.add_edit_fields[0], DATE_FORMAT);
-        let description = self.add_edit_fields[1].trim();
-        let amount_str = self.add_edit_fields[2].trim();
-        let type_str = self.add_edit_fields[3].trim().to_lowercase();
-        let category = self.add_edit_fields[4].trim();
-        let subcategory = self.add_edit_fields[5].trim();
+        let date_res =
+            NaiveDate::parse_from_str(&self.add_edit_fields[AddEditField::Date], DATE_FORMAT);
+        let description = self.add_edit_fields[AddEditField::Description].trim();
+        let amount_str = self.add_edit_fields[AddEditField::Amount].trim();
+        let type_str = self.add_edit_fields[AddEditField::TransactionType]
+            .trim()
+            .to_lowercase();
+        let category = self.add_edit_fields[AddEditField::Category].trim();
+        let subcategory = self.add_edit_fields[AddEditField::Subcategory].trim();
 
         let transaction_type = if type_str.starts_with('i') {
             TransactionType::Income
@@ -169,8 +171,7 @@ impl App {
 
                     self.mode = crate::app::state::AppMode::Editing;
                     self.editing_index = Some(target_index);
-                    self.current_add_edit_field = 0;
-                    self.add_edit_fields = [
+                    self.add_edit_fields = FieldSet::new([
                         target_tx.date.format(DATE_FORMAT).to_string(),
                         target_tx.description.clone(),
                         format!("{:.2}", target_tx.amount),
@@ -181,8 +182,8 @@ impl App {
                         },
                         target_tx.category.clone(),
                         target_tx.subcategory.clone(),
-                    ];
-                    self.add_edit_cursor = self.add_edit_fields[0].len();
+                    ]);
+                    self.add_edit_cursor = self.add_edit_fields[AddEditField::Date].len();
 
                     if target_index == original_index {
                         self.clear_status_message();
@@ -198,7 +199,6 @@ impl App {
     pub(crate) fn exit_editing(&mut self, cancelled: bool) {
         self.mode = crate::app::state::AppMode::Normal;
         self.editing_index = None;
-        self.current_add_edit_field = 0;
         self.add_edit_fields = Default::default();
         if cancelled {
             self.set_status_message("Edit transaction cancelled.", Some(Duration::seconds(3)));
@@ -208,12 +208,15 @@ impl App {
     }
     pub(crate) fn update_transaction(&mut self) {
         if let Some(index) = self.editing_index {
-            let date_res = NaiveDate::parse_from_str(&self.add_edit_fields[0], DATE_FORMAT);
-            let description = self.add_edit_fields[1].trim();
-            let amount_str = self.add_edit_fields[2].trim();
-            let type_str = self.add_edit_fields[3].trim().to_lowercase();
-            let category = self.add_edit_fields[4].trim();
-            let subcategory = self.add_edit_fields[5].trim();
+            let date_res =
+                NaiveDate::parse_from_str(&self.add_edit_fields[AddEditField::Date], DATE_FORMAT);
+            let description = self.add_edit_fields[AddEditField::Description].trim();
+            let amount_str = self.add_edit_fields[AddEditField::Amount].trim();
+            let type_str = self.add_edit_fields[AddEditField::TransactionType]
+                .trim()
+                .to_lowercase();
+            let category = self.add_edit_fields[AddEditField::Category].trim();
+            let subcategory = self.add_edit_fields[AddEditField::Subcategory].trim();
 
             let transaction_type = if type_str.starts_with('i') {
                 TransactionType::Income
@@ -309,31 +312,29 @@ impl App {
     }
     // --- Field Navigation ---
     pub(crate) fn next_add_edit_field(&mut self) {
-        self.current_add_edit_field =
-            (self.current_add_edit_field + 1) % self.add_edit_fields.len();
-        self.add_edit_cursor = self.add_edit_fields[self.current_add_edit_field].len();
+        self.add_edit_fields.focus_next();
+        self.add_edit_cursor = self.add_edit_fields.focused_value().len();
     }
 
     pub(crate) fn previous_add_edit_field(&mut self) {
-        if self.current_add_edit_field == 0 {
-            self.current_add_edit_field = self.add_edit_fields.len() - 1;
-        } else {
-            self.current_add_edit_field -= 1;
-        }
-        self.add_edit_cursor = self.add_edit_fields[self.current_add_edit_field].len();
+        self.add_edit_fields.focus_previous();
+        self.add_edit_cursor = self.add_edit_fields.focused_value().len();
     }
 
     // --- Toggle Transaction Type ---
     // Switches between Income and Expense, and clears category/subcategory if type changes.
     pub(crate) fn toggle_transaction_type(&mut self) {
-        if self.current_add_edit_field == 3 {
-            self.add_edit_fields[3] = if self.add_edit_fields[3].eq_ignore_ascii_case("income") {
+        if self.add_edit_fields.focused() == AddEditField::TransactionType {
+            self.add_edit_fields[AddEditField::TransactionType] = if self.add_edit_fields
+                [AddEditField::TransactionType]
+                .eq_ignore_ascii_case("income")
+            {
                 "Expense".to_string()
             } else {
                 "Income".to_string()
             };
-            self.add_edit_fields[4] = String::new();
-            self.add_edit_fields[5] = String::new();
+            self.add_edit_fields[AddEditField::Category] = String::new();
+            self.add_edit_fields[AddEditField::Subcategory] = String::new();
         }
     }
     // --- Copying Logic ---

--- a/src/app/category_manager.rs
+++ b/src/app/category_manager.rs
@@ -1,4 +1,5 @@
 use super::state::App;
+use crate::app::fields::{CategoryEditField, FieldSet};
 use crate::app::state::AppMode;
 use crate::db::category_store::CategoryStore;
 use crate::model::{CategoryDraft, CategoryRecord, TransactionType};
@@ -154,15 +155,15 @@ impl App {
     pub(crate) fn start_adding_category(&mut self) {
         self.mode = AppMode::CategoryEditor;
         self.editing_category_id = None;
-        self.current_category_field = 0;
-        self.category_edit_fields = [
+        self.category_edit_fields = FieldSet::new([
             TransactionType::Expense.to_string(),
             String::new(),
             String::new(),
             String::new(),
             String::new(),
-        ];
-        self.category_edit_cursor = self.category_edit_fields[0].len();
+        ]);
+        self.category_edit_cursor =
+            self.category_edit_fields[CategoryEditField::TransactionType].len();
         self.clear_status_message();
     }
 
@@ -174,7 +175,6 @@ impl App {
 
         self.mode = AppMode::CategoryEditor;
         self.editing_category_id = Some(record.id);
-        self.current_category_field = 0;
         let draft = record.to_draft();
         let target_budget = if draft.transaction_type == TransactionType::Expense {
             draft
@@ -184,21 +184,21 @@ impl App {
         } else {
             String::new()
         };
-        self.category_edit_fields = [
+        self.category_edit_fields = FieldSet::new([
             draft.transaction_type.to_string(),
             draft.category,
             draft.subcategory,
             draft.tag.unwrap_or_default(),
             target_budget,
-        ];
-        self.category_edit_cursor = self.category_edit_fields[0].len();
+        ]);
+        self.category_edit_cursor =
+            self.category_edit_fields[CategoryEditField::TransactionType].len();
         self.clear_status_message();
     }
 
     pub(crate) fn exit_category_editor(&mut self, cancelled: bool) {
         self.mode = AppMode::CategoryCatalog;
         self.editing_category_id = None;
-        self.current_category_field = 0;
         self.category_edit_fields = Default::default();
         self.category_edit_cursor = 0;
 
@@ -210,33 +210,30 @@ impl App {
     }
 
     pub(crate) fn next_category_field(&mut self) {
-        self.current_category_field =
-            (self.current_category_field + 1) % self.category_edit_fields.len();
-        self.category_edit_cursor = self.category_edit_fields[self.current_category_field].len();
+        self.category_edit_fields.focus_next();
+        self.category_edit_cursor = self.category_edit_fields.focused_value().len();
     }
 
     pub(crate) fn previous_category_field(&mut self) {
-        if self.current_category_field == 0 {
-            self.current_category_field = self.category_edit_fields.len() - 1;
-        } else {
-            self.current_category_field -= 1;
-        }
-        self.category_edit_cursor = self.category_edit_fields[self.current_category_field].len();
+        self.category_edit_fields.focus_previous();
+        self.category_edit_cursor = self.category_edit_fields.focused_value().len();
     }
 
     pub(crate) fn toggle_category_transaction_type(&mut self) {
-        if self.current_category_field != 0 {
+        if self.category_edit_fields.focused() != CategoryEditField::TransactionType {
             return;
         }
 
-        let switching_to_income = !self.category_edit_fields[0].eq_ignore_ascii_case("income");
-        self.category_edit_fields[0] = if switching_to_income {
-            self.category_edit_fields[4].clear();
+        let switching_to_income = !self.category_edit_fields[CategoryEditField::TransactionType]
+            .eq_ignore_ascii_case("income");
+        self.category_edit_fields[CategoryEditField::TransactionType] = if switching_to_income {
+            self.category_edit_fields[CategoryEditField::TargetBudget].clear();
             TransactionType::Income.to_string()
         } else {
             TransactionType::Expense.to_string()
         };
-        self.category_edit_cursor = self.category_edit_fields[0].len();
+        self.category_edit_cursor =
+            self.category_edit_fields[CategoryEditField::TransactionType].len();
     }
 
     pub(crate) fn prepare_delete_category(&mut self) {
@@ -320,9 +317,8 @@ impl App {
         });
         let editing_category_id = self.editing_category_id;
 
-        // The schema's UNIQUE constraint compares case-sensitively, but rename and delete
-        // propagate to transactions with LOWER(), so a case-variant pair would let an edit to
-        // one record rewrite the other's transactions. Reject the duplicate here instead.
+        // The schema's UNIQUE is case-sensitive but rename and delete propagate with LOWER(), so
+        // a case-variant pair would let an edit to one record rewrite the other's transactions.
         let duplicate = self.category_records.iter().any(|record| {
             Some(record.id) != editing_category_id
                 && record.transaction_type == draft.transaction_type
@@ -377,7 +373,6 @@ impl App {
 
         self.mode = AppMode::CategoryCatalog;
         self.editing_category_id = Some(saved_id);
-        self.current_category_field = 0;
         self.category_edit_fields = Default::default();
         self.category_edit_cursor = 0;
         self.select_saved_category();
@@ -423,12 +418,18 @@ impl App {
     }
 
     fn build_category_draft_from_editor(&self) -> Result<CategoryDraft, String> {
-        let transaction_type = TransactionType::try_from(self.category_edit_fields[0].trim())
-            .map_err(|_| "Transaction type must be Income or Expense.".to_string())?;
-        let category = self.category_edit_fields[1].trim().to_string();
-        let subcategory = self.category_edit_fields[2].trim().to_string();
-        let tag = self.category_edit_fields[3].trim();
-        let target_budget_str = self.category_edit_fields[4].trim();
+        let transaction_type = TransactionType::try_from(
+            self.category_edit_fields[CategoryEditField::TransactionType].trim(),
+        )
+        .map_err(|_| "Transaction type must be Income or Expense.".to_string())?;
+        let category = self.category_edit_fields[CategoryEditField::Category]
+            .trim()
+            .to_string();
+        let subcategory = self.category_edit_fields[CategoryEditField::Subcategory]
+            .trim()
+            .to_string();
+        let tag = self.category_edit_fields[CategoryEditField::Tag].trim();
+        let target_budget_str = self.category_edit_fields[CategoryEditField::TargetBudget].trim();
 
         if category.is_empty() {
             return Err("Category cannot be empty.".to_string());

--- a/src/app/category_select.rs
+++ b/src/app/category_select.rs
@@ -1,4 +1,5 @@
 use super::state::App;
+use crate::app::fields::{AddEditField, SelectingField};
 use crate::model::TransactionType;
 use ratatui::widgets::ListState;
 use std::collections::HashSet;
@@ -13,9 +14,9 @@ impl App {
         }
         self.type_to_select.clear();
 
-        self.selecting_field_index = Some(4);
+        self.selecting_field = Some(SelectingField::AddEdit(AddEditField::Category));
         self.mode = crate::app::state::AppMode::SelectingCategory;
-        let current_type_str = self.add_edit_fields[3].trim();
+        let current_type_str = self.add_edit_fields[AddEditField::TransactionType].trim();
         let Ok(current_type) = TransactionType::try_from(current_type_str) else {
             self.set_status_message("Error: Invalid transaction type for category lookup.", None);
             self.mode = if self.editing_index.is_some() {
@@ -41,10 +42,10 @@ impl App {
     }
     pub(crate) fn start_subcategory_selection(&mut self) {
         self.type_to_select.clear();
-        self.selecting_field_index = Some(5);
+        self.selecting_field = Some(SelectingField::AddEdit(AddEditField::Subcategory));
         self.mode = crate::app::state::AppMode::SelectingSubcategory;
-        let current_type_str = self.add_edit_fields[3].trim();
-        let current_category = self.add_edit_fields[4].trim();
+        let current_type_str = self.add_edit_fields[AddEditField::TransactionType].trim();
+        let current_category = self.add_edit_fields[AddEditField::Category].trim();
         let Ok(current_type) = TransactionType::try_from(current_type_str) else {
             self.set_status_message(
                 "Error: Invalid transaction type for subcategory lookup.",
@@ -82,22 +83,22 @@ impl App {
     }
     pub(crate) fn confirm_selection(&mut self) {
         if let Some(selected_index) = self.selection_list_state.selected()
-            && let Some(field_index) = self.selecting_field_index
+            && let Some(field) = self.selecting_field.and_then(SelectingField::add_edit)
             && let Some(selected_value) = self.current_selection_list.get(selected_index)
         {
-            let value_to_set = if field_index == 5 && selected_value == "(None)" {
+            let value_to_set = if field == AddEditField::Subcategory && selected_value == "(None)" {
                 ""
             } else {
                 selected_value.as_str()
             };
-            self.add_edit_fields[field_index] = value_to_set.to_string();
-            if field_index == 4 {
-                self.current_add_edit_field = 5;
+            self.add_edit_fields[field] = value_to_set.to_string();
+            if field == AddEditField::Category {
+                self.add_edit_fields.focus(AddEditField::Subcategory);
                 self.start_subcategory_selection();
                 return;
-            } else if field_index == 5 {
-                self.current_add_edit_field = 0;
-                self.add_edit_cursor = self.add_edit_fields[0].len();
+            } else if field == AddEditField::Subcategory {
+                self.add_edit_fields.focus(AddEditField::Date);
+                self.add_edit_cursor = self.add_edit_fields[AddEditField::Date].len();
             }
         }
         self.mode = if self.editing_index.is_some() {
@@ -105,7 +106,7 @@ impl App {
         } else {
             crate::app::state::AppMode::Adding
         };
-        self.selecting_field_index = None;
+        self.selecting_field = None;
         self.current_selection_list.clear();
     }
     pub(crate) fn cancel_selection(&mut self) {
@@ -114,10 +115,10 @@ impl App {
         } else {
             crate::app::state::AppMode::Adding
         };
-        if let Some(field_index) = self.selecting_field_index {
-            self.current_add_edit_field = field_index;
+        if let Some(field) = self.selecting_field.and_then(SelectingField::add_edit) {
+            self.add_edit_fields.focus(field);
         }
-        self.selecting_field_index = None;
+        self.selecting_field = None;
         self.current_selection_list.clear();
     }
     pub(crate) fn select_next_list_item(&mut self) {

--- a/src/app/fields.rs
+++ b/src/app/fields.rs
@@ -1,0 +1,236 @@
+//! Form fields addressed by name instead of by index, in the same spirit as
+//! [`crate::app::settings_types::SettingKey`]. Each form declares its fields once, and everything
+//! keyed off a field (label, input handling, cursor, rendering) derives from that declaration
+//! rather than from a separate list of indices that can drift out of alignment.
+
+use std::marker::PhantomData;
+use std::ops::{Index, IndexMut};
+
+/// How a field behaves: what typing does to it, and what the arrow keys do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FieldKind {
+    Text,
+    Date,
+    Amount,
+    /// Arrow keys cycle a fixed set of values.
+    Toggle,
+    /// Enter opens a picker.
+    Selection,
+}
+
+impl FieldKind {
+    pub const fn is_editable(self) -> bool {
+        matches!(self, Self::Text | Self::Date | Self::Amount)
+    }
+}
+
+/// The fields of one form, in the order they appear on screen.
+pub trait FieldKey: Copy + Eq + 'static {
+    const ALL: &'static [Self];
+
+    fn index(self) -> usize;
+    fn kind(self) -> FieldKind;
+    fn label(self) -> &'static str;
+
+    fn hint(self) -> &'static str {
+        ""
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FieldSet<K: FieldKey, const N: usize> {
+    values: [String; N],
+    focused: usize,
+    key: PhantomData<K>,
+}
+
+impl<K: FieldKey, const N: usize> FieldSet<K, N> {
+    /// Fails the build if `N` disagrees with the number of declared fields.
+    const LENGTH_MATCHES_KEYS: () = assert!(
+        N == K::ALL.len(),
+        "FieldSet length must match the number of fields declared by its key enum"
+    );
+
+    pub fn new(values: [String; N]) -> Self {
+        let () = Self::LENGTH_MATCHES_KEYS;
+        Self {
+            values,
+            focused: 0,
+            key: PhantomData,
+        }
+    }
+
+    pub fn focused(&self) -> K {
+        K::ALL[self.focused]
+    }
+
+    pub fn focus(&mut self, field: K) {
+        self.focused = field.index();
+    }
+
+    pub fn focus_next(&mut self) {
+        self.focused = (self.focused + 1) % N;
+    }
+
+    pub fn focus_previous(&mut self) {
+        self.focused = if self.focused == 0 {
+            N - 1
+        } else {
+            self.focused - 1
+        };
+    }
+
+    pub fn focused_value(&self) -> &String {
+        &self.values[self.focused]
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (K, &String)> {
+        K::ALL.iter().copied().zip(self.values.iter())
+    }
+
+    pub fn all_empty(&self) -> bool {
+        self.values.iter().all(|value| value.is_empty())
+    }
+
+    /// Blanks every field and returns focus to the first one.
+    pub fn reset(&mut self) {
+        for value in self.values.iter_mut() {
+            value.clear();
+        }
+        self.focused = 0;
+    }
+}
+
+impl<K: FieldKey, const N: usize> Default for FieldSet<K, N> {
+    fn default() -> Self {
+        Self::new(std::array::from_fn(|_| String::new()))
+    }
+}
+
+impl<K: FieldKey, const N: usize> Index<K> for FieldSet<K, N> {
+    type Output = String;
+
+    fn index(&self, field: K) -> &String {
+        &self.values[field.index()]
+    }
+}
+
+impl<K: FieldKey, const N: usize> IndexMut<K> for FieldSet<K, N> {
+    fn index_mut(&mut self, field: K) -> &mut String {
+        &mut self.values[field.index()]
+    }
+}
+
+/// Declares a form's fields in one table. Variant order is screen order, and every arm is
+/// required, so a new field cannot be added without giving it a kind and a label.
+macro_rules! form_fields {
+    (
+        $(#[$meta:meta])*
+        $vis:vis enum $name:ident {
+            $($variant:ident => $kind:expr, $label:literal $(, $hint:literal)? ;)+
+        }
+    ) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        $vis enum $name {
+            $($variant),+
+        }
+
+        impl crate::app::fields::FieldKey for $name {
+            const ALL: &'static [Self] = &[$(Self::$variant),+];
+
+            fn index(self) -> usize {
+                self as usize
+            }
+
+            fn kind(self) -> crate::app::fields::FieldKind {
+                match self {
+                    $(Self::$variant => $kind),+
+                }
+            }
+
+            fn label(self) -> &'static str {
+                match self {
+                    $(Self::$variant => $label),+
+                }
+            }
+
+            fn hint(self) -> &'static str {
+                match self {
+                    $(Self::$variant => concat!("", $($hint)?)),+
+                }
+            }
+        }
+    };
+}
+
+form_fields! {
+    pub enum AddEditField {
+        Date => FieldKind::Date, "Date (YYYY-MM-DD)",
+            "(◀/▶ or +/- for days, Shift+◀/▶ for months, Digits to enter)";
+        Description => FieldKind::Text, "Description";
+        Amount => FieldKind::Amount, "Amount";
+        TransactionType => FieldKind::Toggle, "Type", "(◀/▶ or Enter to toggle)";
+        Category => FieldKind::Selection, "Category", "(Enter to select)";
+        Subcategory => FieldKind::Selection, "Subcategory", "(Enter to select)";
+    }
+}
+
+form_fields! {
+    pub enum AdvancedFilterField {
+        DateFrom => FieldKind::Date, "Date From (YYYY-MM-DD)",
+            "(◀/▶ or +/- days, Shift+◀/▶ months (jumps to today if empty), Digits to enter)";
+        DateTo => FieldKind::Date, "Date To (YYYY-MM-DD)",
+            "(◀/▶ or +/- days, Shift+◀/▶ months (jumps to today if empty), Digits to enter)";
+        Description => FieldKind::Text, "Description";
+        Category => FieldKind::Selection, "Category", "(Enter to select)";
+        Subcategory => FieldKind::Selection, "Subcategory", "(Enter to select)";
+        TransactionType => FieldKind::Toggle, "Type", "(◀/▶)";
+        Recurring => FieldKind::Toggle, "Recurring", "(◀/▶)";
+        AmountFrom => FieldKind::Amount, "Amount From";
+        AmountTo => FieldKind::Amount, "Amount To";
+    }
+}
+
+form_fields! {
+    pub enum CategoryEditField {
+        TransactionType => FieldKind::Toggle, "Transaction Type", "(Left/Right or Enter to toggle)";
+        Category => FieldKind::Text, "Category";
+        Subcategory => FieldKind::Text, "Subcategory", "(Optional)";
+        Tag => FieldKind::Text, "Tag", "(Optional)";
+        TargetBudget => FieldKind::Amount, "Target Budget", "(Optional, positive number)";
+    }
+}
+
+form_fields! {
+    pub enum RecurringField {
+        IsRecurring => FieldKind::Toggle, "Is Recurring", "(◀/▶ to toggle)";
+        Frequency => FieldKind::Selection, "Frequency", "(Enter to select)";
+        EndDate => FieldKind::Date, "End Date (YYYY-MM-DD)",
+            "(Optional - ◀/▶ days, Shift+◀/▶ months, jumps to today if empty)";
+    }
+}
+
+/// Which form a category picker was opened from. The two forms have separate field sets, so a
+/// shared index could send the picked value back to the wrong one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelectingField {
+    AddEdit(AddEditField),
+    AdvancedFilter(AdvancedFilterField),
+}
+
+impl SelectingField {
+    pub fn add_edit(self) -> Option<AddEditField> {
+        match self {
+            Self::AddEdit(field) => Some(field),
+            Self::AdvancedFilter(_) => None,
+        }
+    }
+
+    pub fn advanced_filter(self) -> Option<AdvancedFilterField> {
+        match self {
+            Self::AdvancedFilter(field) => Some(field),
+            Self::AddEdit(_) => None,
+        }
+    }
+}

--- a/src/app/filter.rs
+++ b/src/app/filter.rs
@@ -1,4 +1,5 @@
 use super::state::App;
+use crate::app::fields::{AdvancedFilterField, FieldKey, FieldKind, SelectingField};
 use crate::model::{DATE_FORMAT, TransactionType};
 use chrono::{Duration, NaiveDate};
 use ratatui::widgets::ListState;
@@ -7,8 +8,7 @@ use std::collections::HashSet;
 
 impl App {
     pub(crate) fn is_filter_active(&self) -> bool {
-        !self.simple_filter_content.is_empty()
-            || self.advanced_filter_fields.iter().any(|f| !f.is_empty())
+        !self.simple_filter_content.is_empty() || !self.advanced_filter_fields.all_empty()
     }
     // --- Filtering Logic ---
     // Handles entering/exiting filtering mode, applying basic filter, and updating filtered indices.
@@ -55,8 +55,9 @@ impl App {
     // Handles advanced filter UI, field navigation, and applying advanced filters to transactions.
     pub(crate) fn start_advanced_filtering(&mut self) {
         self.mode = crate::app::state::AppMode::AdvancedFiltering;
-        self.current_advanced_filter_field = 0;
-        self.advanced_filter_cursor = self.advanced_filter_fields[0].len();
+        self.advanced_filter_fields
+            .focus(AdvancedFilterField::DateFrom);
+        self.advanced_filter_cursor = self.advanced_filter_fields.focused_value().len();
         self.clear_status_message()
     }
     pub(crate) fn cancel_advanced_filtering(&mut self) {
@@ -92,10 +93,7 @@ impl App {
     }
     pub(crate) fn clear_advanced_filter_fields_only(&mut self) {
         // Clear advanced filter fields without changing mode
-        for f in self.advanced_filter_fields.iter_mut() {
-            f.clear();
-        }
-        self.current_advanced_filter_field = 0;
+        self.advanced_filter_fields.reset();
     }
     pub(crate) fn clear_simple_filter_field_only(&mut self) {
         // Clear simple filter field without changing mode
@@ -103,23 +101,16 @@ impl App {
         self.simple_filter_cursor = 0;
     }
     pub(crate) fn next_advanced_filter_field(&mut self) {
-        self.current_advanced_filter_field =
-            (self.current_advanced_filter_field + 1) % self.advanced_filter_fields.len();
-        self.advanced_filter_cursor =
-            self.advanced_filter_fields[self.current_advanced_filter_field].len();
+        self.advanced_filter_fields.focus_next();
+        self.advanced_filter_cursor = self.advanced_filter_fields.focused_value().len();
     }
     pub(crate) fn previous_advanced_filter_field(&mut self) {
-        if self.current_advanced_filter_field == 0 {
-            self.current_advanced_filter_field = self.advanced_filter_fields.len() - 1;
-        } else {
-            self.current_advanced_filter_field -= 1;
-        }
-        self.advanced_filter_cursor =
-            self.advanced_filter_fields[self.current_advanced_filter_field].len();
+        self.advanced_filter_fields.focus_previous();
+        self.advanced_filter_cursor = self.advanced_filter_fields.focused_value().len();
     }
     pub(crate) fn toggle_advanced_transaction_type(&mut self) {
         self.clear_simple_filter_field_only();
-        let ft = self.advanced_filter_fields[5].trim();
+        let ft = self.advanced_filter_fields[AdvancedFilterField::TransactionType].trim();
         let new_val = if ft.is_empty() {
             "Income"
         } else if ft.eq_ignore_ascii_case("Income") {
@@ -127,11 +118,11 @@ impl App {
         } else {
             ""
         };
-        self.advanced_filter_fields[5] = new_val.to_string();
+        self.advanced_filter_fields[AdvancedFilterField::TransactionType] = new_val.to_string();
     }
     pub(crate) fn toggle_advanced_recurring(&mut self) {
         self.clear_simple_filter_field_only();
-        let fr = self.advanced_filter_fields[6].trim();
+        let fr = self.advanced_filter_fields[AdvancedFilterField::Recurring].trim();
         let new_val = if fr.is_empty() {
             "Recurring"
         } else if fr.eq_ignore_ascii_case("Recurring") {
@@ -139,11 +130,13 @@ impl App {
         } else {
             ""
         };
-        self.advanced_filter_fields[6] = new_val.to_string();
+        self.advanced_filter_fields[AdvancedFilterField::Recurring] = new_val.to_string();
     }
     pub(crate) fn start_advanced_category_selection(&mut self) {
         self.type_to_select.clear();
-        self.selecting_field_index = Some(3);
+        self.selecting_field = Some(SelectingField::AdvancedFilter(
+            AdvancedFilterField::Category,
+        ));
         self.mode = crate::app::state::AppMode::SelectingFilterCategory;
         let mut unique: HashSet<String> =
             self.categories.iter().map(|c| c.category.clone()).collect();
@@ -157,9 +150,11 @@ impl App {
     }
     pub(crate) fn start_advanced_subcategory_selection(&mut self) {
         self.type_to_select.clear();
-        self.selecting_field_index = Some(4);
+        self.selecting_field = Some(SelectingField::AdvancedFilter(
+            AdvancedFilterField::Subcategory,
+        ));
         self.mode = crate::app::state::AppMode::SelectingFilterSubcategory;
-        let current_cat = self.advanced_filter_fields[3].trim();
+        let current_cat = self.advanced_filter_fields[AdvancedFilterField::Category].trim();
         let mut unique: HashSet<String> = self
             .categories
             .iter()
@@ -178,36 +173,44 @@ impl App {
     }
     pub(crate) fn confirm_advanced_selection(&mut self) {
         if let Some(idx) = self.selection_list_state.selected()
-            && let Some(fi) = self.selecting_field_index
+            && let Some(field) = self
+                .selecting_field
+                .and_then(SelectingField::advanced_filter)
             && let Some(val) = self.current_selection_list.get(idx)
         {
             let val_clone = val.clone();
             self.clear_simple_filter_field_only();
-            let v = if fi == 4 && val_clone == "(None)" {
+            let v = if field == AdvancedFilterField::Subcategory && val_clone == "(None)" {
                 ""
             } else {
                 val_clone.as_str()
             };
-            self.advanced_filter_fields[fi] = v.to_string();
-            if fi == 3 {
+            self.advanced_filter_fields[field] = v.to_string();
+            if field == AdvancedFilterField::Category {
                 self.start_advanced_subcategory_selection();
                 return;
             }
         }
         self.mode = crate::app::state::AppMode::AdvancedFiltering;
-        if let Some(fi) = self.selecting_field_index {
-            self.current_advanced_filter_field = fi;
-            self.advanced_filter_cursor = self.advanced_filter_fields[fi].len();
+        if let Some(field) = self
+            .selecting_field
+            .and_then(SelectingField::advanced_filter)
+        {
+            self.advanced_filter_fields.focus(field);
+            self.advanced_filter_cursor = self.advanced_filter_fields.focused_value().len();
         }
-        self.selecting_field_index = None;
+        self.selecting_field = None;
         self.current_selection_list.clear();
     }
     pub(crate) fn cancel_advanced_selection(&mut self) {
         self.mode = crate::app::state::AppMode::AdvancedFiltering;
-        if let Some(fi) = self.selecting_field_index {
-            self.current_advanced_filter_field = fi;
+        if let Some(field) = self
+            .selecting_field
+            .and_then(SelectingField::advanced_filter)
+        {
+            self.advanced_filter_fields.focus(field);
         }
-        self.selecting_field_index = None;
+        self.selecting_field = None;
         self.current_selection_list.clear();
     }
     pub(crate) fn apply_advanced_filter(&mut self) {
@@ -216,16 +219,27 @@ impl App {
             self.sort_by,
             self.sort_order,
         );
-        let date_from =
-            NaiveDate::parse_from_str(&self.advanced_filter_fields[0], DATE_FORMAT).ok();
-        let date_to = NaiveDate::parse_from_str(&self.advanced_filter_fields[1], DATE_FORMAT).ok();
-        let desc_q = self.advanced_filter_fields[2].to_lowercase();
-        let cat_q = self.advanced_filter_fields[3].to_lowercase();
-        let sub_q = self.advanced_filter_fields[4].to_lowercase();
-        let type_q = self.advanced_filter_fields[5].trim();
-        let recurring_q = self.advanced_filter_fields[6].trim();
-        let amt_from = self.advanced_filter_fields[7].parse::<Decimal>().ok();
-        let amt_to = self.advanced_filter_fields[8].parse::<Decimal>().ok();
+        let date_from = NaiveDate::parse_from_str(
+            &self.advanced_filter_fields[AdvancedFilterField::DateFrom],
+            DATE_FORMAT,
+        )
+        .ok();
+        let date_to = NaiveDate::parse_from_str(
+            &self.advanced_filter_fields[AdvancedFilterField::DateTo],
+            DATE_FORMAT,
+        )
+        .ok();
+        let desc_q = self.advanced_filter_fields[AdvancedFilterField::Description].to_lowercase();
+        let cat_q = self.advanced_filter_fields[AdvancedFilterField::Category].to_lowercase();
+        let sub_q = self.advanced_filter_fields[AdvancedFilterField::Subcategory].to_lowercase();
+        let type_q = self.advanced_filter_fields[AdvancedFilterField::TransactionType].trim();
+        let recurring_q = self.advanced_filter_fields[AdvancedFilterField::Recurring].trim();
+        let amt_from = self.advanced_filter_fields[AdvancedFilterField::AmountFrom]
+            .parse::<Decimal>()
+            .ok();
+        let amt_to = self.advanced_filter_fields[AdvancedFilterField::AmountTo]
+            .parse::<Decimal>()
+            .ok();
         self.filtered_indices = self
             .transactions
             .iter()
@@ -291,42 +305,44 @@ impl App {
         self.calculate_monthly_summaries();
     }
     pub(crate) fn increment_advanced_date(&mut self) {
-        let idx = self.current_advanced_filter_field;
-        if idx == 0 || idx == 1 {
+        let field = self.advanced_filter_fields.focused();
+        if field.kind() == FieldKind::Date {
             self.clear_simple_filter_field_only();
-            if let Some(new_date) = self.increment_date_field(&self.advanced_filter_fields[idx]) {
-                self.advanced_filter_fields[idx] = new_date;
-                self.advanced_filter_cursor = self.advanced_filter_fields[idx].len();
+            if let Some(new_date) = self.increment_date_field(&self.advanced_filter_fields[field]) {
+                self.advanced_filter_fields[field] = new_date;
+                self.advanced_filter_cursor = self.advanced_filter_fields[field].len();
             }
         }
     }
     pub(crate) fn decrement_advanced_date(&mut self) {
-        let idx = self.current_advanced_filter_field;
-        if idx == 0 || idx == 1 {
+        let field = self.advanced_filter_fields.focused();
+        if field.kind() == FieldKind::Date {
             self.clear_simple_filter_field_only();
-            if let Some(new_date) = self.decrement_date_field(&self.advanced_filter_fields[idx]) {
-                self.advanced_filter_fields[idx] = new_date;
-                self.advanced_filter_cursor = self.advanced_filter_fields[idx].len();
+            if let Some(new_date) = self.decrement_date_field(&self.advanced_filter_fields[field]) {
+                self.advanced_filter_fields[field] = new_date;
+                self.advanced_filter_cursor = self.advanced_filter_fields[field].len();
             }
         }
     }
     pub(crate) fn increment_advanced_month(&mut self) {
-        let idx = self.current_advanced_filter_field;
-        if idx == 0 || idx == 1 {
+        let field = self.advanced_filter_fields.focused();
+        if field.kind() == FieldKind::Date {
             self.clear_simple_filter_field_only();
-            if let Some(new_date) = self.increment_month_field(&self.advanced_filter_fields[idx]) {
-                self.advanced_filter_fields[idx] = new_date;
-                self.advanced_filter_cursor = self.advanced_filter_fields[idx].len();
+            if let Some(new_date) = self.increment_month_field(&self.advanced_filter_fields[field])
+            {
+                self.advanced_filter_fields[field] = new_date;
+                self.advanced_filter_cursor = self.advanced_filter_fields[field].len();
             }
         }
     }
     pub(crate) fn decrement_advanced_month(&mut self) {
-        let idx = self.current_advanced_filter_field;
-        if idx == 0 || idx == 1 {
+        let field = self.advanced_filter_fields.focused();
+        if field.kind() == FieldKind::Date {
             self.clear_simple_filter_field_only();
-            if let Some(new_date) = self.decrement_month_field(&self.advanced_filter_fields[idx]) {
-                self.advanced_filter_fields[idx] = new_date;
-                self.advanced_filter_cursor = self.advanced_filter_fields[idx].len();
+            if let Some(new_date) = self.decrement_month_field(&self.advanced_filter_fields[field])
+            {
+                self.advanced_filter_fields[field] = new_date;
+                self.advanced_filter_cursor = self.advanced_filter_fields[field].len();
             }
         }
     }

--- a/src/app/fuzzy_search.rs
+++ b/src/app/fuzzy_search.rs
@@ -1,4 +1,5 @@
 use super::state::App;
+use crate::app::fields::{AddEditField, SelectingField};
 use crate::model::TransactionType;
 use ratatui::widgets::ListState;
 use std::collections::HashSet;
@@ -7,7 +8,7 @@ impl App {
     // --- Fuzzy Search Logic ---
 
     pub(crate) fn start_fuzzy_selection(&mut self) {
-        self.selecting_field_index = Some(4); // Start pretending we are selecting category
+        self.selecting_field = Some(SelectingField::AddEdit(AddEditField::Category));
         self.mode = crate::app::state::AppMode::FuzzyFinding;
         self.search_query = String::new();
         self.update_fuzzy_search_results();
@@ -20,7 +21,7 @@ impl App {
     }
 
     pub(crate) fn update_fuzzy_search_results(&mut self) {
-        let current_type_str = self.add_edit_fields[3].trim();
+        let current_type_str = self.add_edit_fields[AddEditField::TransactionType].trim();
         let Ok(current_type) = TransactionType::try_from(current_type_str) else {
             self.current_selection_list.clear();
             return;
@@ -79,11 +80,9 @@ impl App {
             let category = parts[0];
             let subcategory = if parts.len() > 1 { parts[1] } else { "" };
 
-            // Set fields
-            // Index 4 is Category, 5 is Subcategory
-            self.add_edit_fields[4] = category.to_string();
-            self.add_edit_fields[5] = subcategory.to_string();
-            self.current_add_edit_field = 0;
+            self.add_edit_fields[AddEditField::Category] = category.to_string();
+            self.add_edit_fields[AddEditField::Subcategory] = subcategory.to_string();
+            self.add_edit_fields.focus(AddEditField::Date);
         }
 
         self.exit_fuzzy_mode();
@@ -92,7 +91,7 @@ impl App {
     pub(crate) fn cancel_fuzzy_selection(&mut self) {
         self.exit_fuzzy_mode();
         // Return to category field focus
-        self.current_add_edit_field = 4;
+        self.add_edit_fields.focus(AddEditField::Category);
     }
 
     fn exit_fuzzy_mode(&mut self) {
@@ -101,7 +100,7 @@ impl App {
         } else {
             crate::app::state::AppMode::Adding
         };
-        self.selecting_field_index = None;
+        self.selecting_field = None;
         self.current_selection_list.clear();
         self.search_query.clear();
     }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -1,79 +1,65 @@
 use super::state::App;
+use crate::app::fields::{FieldKey, FieldKind};
 use crate::app::state::AppMode;
 use crate::model::DATE_FORMAT;
 use chrono::NaiveDate;
 
-#[derive(PartialEq)]
-pub enum InputType {
-    Text,
-    Date,
-    Amount,
-}
-
 impl App {
-    // Helper to get the active mutable input field state based on the current mode and field index.
-    // Returns: (content_string, cursor_position, input_type)
-    fn get_active_input_mut(&mut self) -> Option<(&mut String, &mut usize, InputType)> {
+    // Returns (content, cursor, kind) for the field being typed into, or None if the current
+    // field is not one (a toggle or a picker).
+    fn get_active_input_mut(&mut self) -> Option<(&mut String, &mut usize, FieldKind)> {
         match self.mode {
             AppMode::Filtering => Some((
                 &mut self.simple_filter_content,
                 &mut self.simple_filter_cursor,
-                InputType::Text,
+                FieldKind::Text,
             )),
             AppMode::CategoryCatalogFilter => Some((
                 &mut self.category_filter_query,
                 &mut self.category_filter_cursor,
-                InputType::Text,
+                FieldKind::Text,
             )),
             AppMode::Adding | AppMode::Editing => {
-                let idx = self.current_add_edit_field;
-                let input_type = match idx {
-                    0 => InputType::Date,
-                    2 => InputType::Amount,
-                    1 => InputType::Text,
-                    _ => return None, // Other fields (Type, Category, Subcategory) are not standard text inputs
-                };
+                let field = self.add_edit_fields.focused();
+                if !field.kind().is_editable() {
+                    return None;
+                }
                 Some((
-                    &mut self.add_edit_fields[idx],
+                    &mut self.add_edit_fields[field],
                     &mut self.add_edit_cursor,
-                    input_type,
+                    field.kind(),
                 ))
             }
             AppMode::CategoryEditor => {
-                let idx = self.current_category_field;
-                let input_type = match idx {
-                    1..=3 => InputType::Text,
-                    4 => InputType::Amount,
-                    _ => return None,
-                };
+                let field = self.category_edit_fields.focused();
+                if !field.kind().is_editable() {
+                    return None;
+                }
                 Some((
-                    &mut self.category_edit_fields[idx],
+                    &mut self.category_edit_fields[field],
                     &mut self.category_edit_cursor,
-                    input_type,
+                    field.kind(),
                 ))
             }
             AppMode::LedgerEditor => Some((
                 &mut self.ledger_name_input,
                 &mut self.ledger_name_cursor,
-                InputType::Text,
+                FieldKind::Text,
             )),
             AppMode::ImportTransactions | AppMode::ExportTransactions => Some((
                 &mut self.io_path_input,
                 &mut self.io_path_cursor,
-                InputType::Text,
+                FieldKind::Text,
             )),
             AppMode::AdvancedFiltering => {
-                let idx = self.current_advanced_filter_field;
-                let input_type = match idx {
-                    0 | 1 => InputType::Date,
-                    2 => InputType::Text, // Description
-                    7 | 8 => InputType::Amount,
-                    _ => return None, // Category(3), Subcategory(4), Type(5), Recurring(6) are selections/toggles
-                };
+                let field = self.advanced_filter_fields.focused();
+                if !field.kind().is_editable() {
+                    return None;
+                }
                 Some((
-                    &mut self.advanced_filter_fields[idx],
+                    &mut self.advanced_filter_fields[field],
                     &mut self.advanced_filter_cursor,
-                    input_type,
+                    field.kind(),
                 ))
             }
             _ => None,
@@ -104,9 +90,9 @@ impl App {
     }
 
     pub(crate) fn insert_char_at_cursor(&mut self, c: char) {
-        if let Some((content, cursor, input_type)) = self.get_active_input_mut() {
-            match input_type {
-                InputType::Date => {
+        if let Some((content, cursor, kind)) = self.get_active_input_mut() {
+            match kind {
+                FieldKind::Date => {
                     if let Some(new_content) =
                         crate::validation::validate_and_insert_date_char(content, c)
                     {
@@ -114,7 +100,7 @@ impl App {
                         *cursor = content.len();
                     }
                 }
-                InputType::Amount => {
+                FieldKind::Amount => {
                     if crate::validation::validate_amount_char(content, c) {
                         if *cursor >= content.len() {
                             content.push(c);
@@ -124,7 +110,7 @@ impl App {
                         *cursor += c.len_utf8();
                     }
                 }
-                InputType::Text => {
+                FieldKind::Text => {
                     if *cursor >= content.len() {
                         content.push(c);
                     } else {
@@ -132,14 +118,16 @@ impl App {
                     }
                     *cursor += c.len_utf8();
                 }
+                // get_active_input_mut never yields these.
+                FieldKind::Toggle | FieldKind::Selection => {}
             }
         }
     }
 
     pub(crate) fn delete_char_before_cursor(&mut self) {
-        if let Some((content, cursor, input_type)) = self.get_active_input_mut() {
-            match input_type {
-                InputType::Date => {
+        if let Some((content, cursor, kind)) = self.get_active_input_mut() {
+            match kind {
+                FieldKind::Date => {
                     // Date backspace logic is specific
                     crate::validation::handle_date_backspace(content);
                     *cursor = content.len();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2,6 +2,7 @@ pub mod add_edit;
 pub mod budget;
 pub mod category_manager;
 pub mod category_select;
+pub mod fields;
 pub mod filter;
 pub mod fuzzy_search;
 pub mod help;

--- a/src/app/recurring.rs
+++ b/src/app/recurring.rs
@@ -1,4 +1,5 @@
 use super::state::App;
+use crate::app::fields::RecurringField;
 use crate::db::transaction_store::TransactionStore;
 use crate::model::{RecurrenceFrequency, Transaction};
 use crate::recurring::{generate_recurring_transactions, remove_generated_recurring_transactions};
@@ -48,16 +49,17 @@ impl App {
 
                     self.mode = crate::app::state::AppMode::RecurringSettings;
                     self.recurring_transaction_index = Some(target_index);
-                    self.current_recurring_field = 0;
+                    self.recurring_settings_fields
+                        .focus(RecurringField::IsRecurring);
 
                     // Initialize fields with current values
-                    self.recurring_settings_fields[0] =
+                    self.recurring_settings_fields[RecurringField::IsRecurring] =
                         if target_tx.is_recurring { "Yes" } else { "No" }.to_string();
-                    self.recurring_settings_fields[1] = target_tx
+                    self.recurring_settings_fields[RecurringField::Frequency] = target_tx
                         .recurrence_frequency
                         .map(|f| f.to_string().to_string())
                         .unwrap_or(String::from("Monthly"));
-                    self.recurring_settings_fields[2] = target_tx
+                    self.recurring_settings_fields[RecurringField::EndDate] = target_tx
                         .recurrence_end_date
                         .map(|d| d.format(crate::model::DATE_FORMAT).to_string())
                         .unwrap_or_default();
@@ -78,7 +80,6 @@ impl App {
     pub(crate) fn exit_recurring_settings(&mut self, cancelled: bool) {
         self.mode = crate::app::state::AppMode::Normal;
         self.recurring_transaction_index = None;
-        self.current_recurring_field = 0;
         self.recurring_settings_fields = Default::default();
         if cancelled {
             self.set_status_message("Recurring settings cancelled.", Some(Duration::seconds(3)));
@@ -88,9 +89,11 @@ impl App {
     pub(crate) fn save_recurring_settings(&mut self) {
         if let Some(index) = self.recurring_transaction_index {
             if index < self.transactions.len() {
-                let is_recurring = self.recurring_settings_fields[0].to_lowercase() == "yes";
-                let frequency_str = &self.recurring_settings_fields[1];
-                let end_date_str = &self.recurring_settings_fields[2];
+                let is_recurring = self.recurring_settings_fields[RecurringField::IsRecurring]
+                    .to_lowercase()
+                    == "yes";
+                let frequency_str = &self.recurring_settings_fields[RecurringField::Frequency];
+                let end_date_str = &self.recurring_settings_fields[RecurringField::EndDate];
 
                 // Parse frequency
                 let frequency = if is_recurring {
@@ -165,29 +168,26 @@ impl App {
     }
 
     pub(crate) fn next_recurring_field(&mut self) {
-        self.current_recurring_field = (self.current_recurring_field + 1) % 3;
+        self.recurring_settings_fields.focus_next();
     }
 
     pub(crate) fn previous_recurring_field(&mut self) {
-        self.current_recurring_field = if self.current_recurring_field == 0 {
-            2
-        } else {
-            self.current_recurring_field - 1
-        };
+        self.recurring_settings_fields.focus_previous();
     }
 
     pub(crate) fn toggle_recurring_enabled(&mut self) {
-        if self.current_recurring_field == 0 {
-            self.recurring_settings_fields[0] = if self.recurring_settings_fields[0] == "Yes" {
-                "No".to_string()
-            } else {
-                "Yes".to_string()
-            };
+        if self.recurring_settings_fields.focused() == RecurringField::IsRecurring {
+            self.recurring_settings_fields[RecurringField::IsRecurring] =
+                if self.recurring_settings_fields[RecurringField::IsRecurring] == "Yes" {
+                    "No".to_string()
+                } else {
+                    "Yes".to_string()
+                };
         }
     }
 
     pub(crate) fn start_frequency_selection(&mut self) {
-        if self.current_recurring_field == 1 {
+        if self.recurring_settings_fields.focused() == RecurringField::Frequency {
             self.mode = crate::app::state::AppMode::SelectingRecurrenceFrequency;
             self.current_selection_list = RecurrenceFrequency::all()
                 .iter()
@@ -198,13 +198,13 @@ impl App {
     }
 
     pub(crate) fn insert_char_recurring(&mut self, c: char) {
-        if self.current_recurring_field == 2 {
+        if self.recurring_settings_fields.focused() == RecurringField::EndDate {
             // Use the centralized date validation from validation module
             if let Some(new_date) = crate::validation::validate_and_insert_date_char(
-                &self.recurring_settings_fields[2],
+                &self.recurring_settings_fields[RecurringField::EndDate],
                 c,
             ) {
-                self.recurring_settings_fields[2] = new_date;
+                self.recurring_settings_fields[RecurringField::EndDate] = new_date;
                 self.clear_status_message(); // Clear any previous error messages
             } else {
                 // Invalid character or date, show error message
@@ -214,44 +214,50 @@ impl App {
     }
 
     pub(crate) fn delete_char_recurring(&mut self) {
-        if self.current_recurring_field == 2 {
-            crate::validation::handle_date_backspace(&mut self.recurring_settings_fields[2]);
+        if self.recurring_settings_fields.focused() == RecurringField::EndDate {
+            crate::validation::handle_date_backspace(
+                &mut self.recurring_settings_fields[RecurringField::EndDate],
+            );
             self.clear_status_message();
         }
     }
 
     pub(crate) fn increment_date_recurring(&mut self) {
-        if self.current_recurring_field == 2
-            && let Some(new_date) = self.increment_date_field(&self.recurring_settings_fields[2])
+        if self.recurring_settings_fields.focused() == RecurringField::EndDate
+            && let Some(new_date) =
+                self.increment_date_field(&self.recurring_settings_fields[RecurringField::EndDate])
         {
-            self.recurring_settings_fields[2] = new_date;
+            self.recurring_settings_fields[RecurringField::EndDate] = new_date;
             self.clear_status_message();
         }
     }
 
     pub(crate) fn decrement_date_recurring(&mut self) {
-        if self.current_recurring_field == 2
-            && let Some(new_date) = self.decrement_date_field(&self.recurring_settings_fields[2])
+        if self.recurring_settings_fields.focused() == RecurringField::EndDate
+            && let Some(new_date) =
+                self.decrement_date_field(&self.recurring_settings_fields[RecurringField::EndDate])
         {
-            self.recurring_settings_fields[2] = new_date;
+            self.recurring_settings_fields[RecurringField::EndDate] = new_date;
             self.clear_status_message();
         }
     }
 
     pub(crate) fn increment_month_recurring(&mut self) {
-        if self.current_recurring_field == 2
-            && let Some(new_date) = self.increment_month_field(&self.recurring_settings_fields[2])
+        if self.recurring_settings_fields.focused() == RecurringField::EndDate
+            && let Some(new_date) =
+                self.increment_month_field(&self.recurring_settings_fields[RecurringField::EndDate])
         {
-            self.recurring_settings_fields[2] = new_date;
+            self.recurring_settings_fields[RecurringField::EndDate] = new_date;
             self.clear_status_message();
         }
     }
 
     pub(crate) fn decrement_month_recurring(&mut self) {
-        if self.current_recurring_field == 2
-            && let Some(new_date) = self.decrement_month_field(&self.recurring_settings_fields[2])
+        if self.recurring_settings_fields.focused() == RecurringField::EndDate
+            && let Some(new_date) =
+                self.decrement_month_field(&self.recurring_settings_fields[RecurringField::EndDate])
         {
-            self.recurring_settings_fields[2] = new_date;
+            self.recurring_settings_fields[RecurringField::EndDate] = new_date;
             self.clear_status_message();
         }
     }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1,3 +1,6 @@
+use crate::app::fields::{
+    AddEditField, AdvancedFilterField, CategoryEditField, FieldSet, RecurringField, SelectingField,
+};
 use crate::app::update_checker;
 use crate::config::{AppSettings, load_settings};
 use crate::csv_io::{load_seed_categories, load_transactions};
@@ -81,11 +84,9 @@ pub struct App {
     pub(crate) mode: AppMode,
     pub(crate) simple_filter_content: String,
     pub(crate) simple_filter_cursor: usize,
-    pub(crate) add_edit_fields: [String; 6],
-    pub(crate) current_add_edit_field: usize,
+    pub(crate) add_edit_fields: FieldSet<AddEditField, 6>,
     pub(crate) add_edit_cursor: usize,
-    pub(crate) advanced_filter_fields: [String; 9],
-    pub(crate) current_advanced_filter_field: usize,
+    pub(crate) advanced_filter_fields: FieldSet<AdvancedFilterField, 9>,
     pub(crate) advanced_filter_cursor: usize,
     pub(crate) delete_index: Option<usize>,
     pub(crate) editing_index: Option<usize>,
@@ -101,7 +102,7 @@ pub struct App {
     pub(crate) summary_multi_month_mode: bool,
     pub(crate) summary_cumulative_mode: bool,
     // Category/Subcategory Selection Popup State
-    pub(crate) selecting_field_index: Option<usize>,
+    pub(crate) selecting_field: Option<SelectingField>,
     pub(crate) current_selection_list: Vec<String>,
     pub(crate) selection_list_state: ListState,
     pub(crate) type_to_select: crate::app::util::TypeToSelect,
@@ -126,8 +127,7 @@ pub struct App {
     pub(crate) filtered_category_indices: Vec<usize>,
     pub(crate) category_filter_query: String,
     pub(crate) category_filter_cursor: usize,
-    pub(crate) category_edit_fields: [String; 5], // [type, category, subcategory, tag, target_budget]
-    pub(crate) current_category_field: usize,
+    pub(crate) category_edit_fields: FieldSet<CategoryEditField, 5>,
     pub(crate) category_edit_cursor: usize,
     pub(crate) editing_category_id: Option<i64>,
     pub(crate) category_delete_id: Option<i64>,
@@ -148,8 +148,7 @@ pub struct App {
     pub(crate) fuzzy_search_mode: bool,
     pub(crate) search_query: String,
     // Recurring transaction state
-    pub(crate) recurring_settings_fields: [String; 3], // [is_recurring, frequency, end_date]
-    pub(crate) current_recurring_field: usize,
+    pub(crate) recurring_settings_fields: FieldSet<RecurringField, 3>,
     pub(crate) recurring_transaction_index: Option<usize>,
     // Months past today that recurring occurrences are projected; 0 stops at today.
     pub(crate) recurring_forecast_months: u32,
@@ -312,10 +311,8 @@ impl App {
             simple_filter_content: String::new(),
             simple_filter_cursor: 0,
             add_edit_fields: Default::default(),
-            current_add_edit_field: 0,
             add_edit_cursor: 0,
             advanced_filter_fields: Default::default(),
-            current_advanced_filter_field: 0,
             advanced_filter_cursor: 0,
             delete_index: None,
             editing_index: None,
@@ -329,7 +326,7 @@ impl App {
             selected_summary_month: None,
             summary_multi_month_mode: false,
             summary_cumulative_mode: false,
-            selecting_field_index: None,
+            selecting_field: None,
             current_selection_list: Vec::new(),
             selection_list_state: ListState::default(),
             type_to_select: crate::app::util::TypeToSelect::new(),
@@ -349,7 +346,6 @@ impl App {
             category_filter_query: String::new(),
             category_filter_cursor: 0,
             category_edit_fields: Default::default(),
-            current_category_field: 0,
             category_edit_cursor: 0,
             editing_category_id: None,
             category_delete_id: None,
@@ -367,7 +363,6 @@ impl App {
             fuzzy_search_mode: loaded_settings.fuzzy_search_mode.unwrap_or(false),
             search_query: String::new(),
             recurring_settings_fields: Default::default(),
-            current_recurring_field: 0,
             recurring_transaction_index: None,
             recurring_forecast_months: loaded_settings
                 .recurring_forecast_months
@@ -886,10 +881,11 @@ impl App {
         }
     }
     pub(crate) fn adjust_date(&mut self, amount: i64, unit: DateUnit) {
-        if self.current_add_edit_field == 0 {
-            if let Ok(current_date) =
-                NaiveDate::parse_from_str(&self.add_edit_fields[0], crate::model::DATE_FORMAT)
-            {
+        if self.add_edit_fields.focused() == AddEditField::Date {
+            if let Ok(current_date) = NaiveDate::parse_from_str(
+                &self.add_edit_fields[AddEditField::Date],
+                crate::model::DATE_FORMAT,
+            ) {
                 let new_date = match unit {
                     DateUnit::Day => {
                         if amount > 0 {
@@ -903,14 +899,15 @@ impl App {
                         crate::validation::add_months(current_date, amount as i32)
                     }
                 };
-                self.add_edit_fields[0] = new_date.format(crate::model::DATE_FORMAT).to_string();
-                self.add_edit_cursor = self.add_edit_fields[0].len();
+                self.add_edit_fields[AddEditField::Date] =
+                    new_date.format(crate::model::DATE_FORMAT).to_string();
+                self.add_edit_cursor = self.add_edit_fields[AddEditField::Date].len();
                 self.clear_status_message() // Clear status on successful adjustment
             } else {
                 self.set_status_message(
                     format!(
                         "Error: Could not parse date '{}'. Use YYYY-MM-DD format.",
-                        self.add_edit_fields[0]
+                        self.add_edit_fields[AddEditField::Date]
                     ),
                     None,
                 );
@@ -961,10 +958,7 @@ impl App {
 
         // Preserve the current filter type when sorting
         // Check if any advanced filter fields are active
-        let has_advanced_filters = self
-            .advanced_filter_fields
-            .iter()
-            .any(|field| !field.is_empty());
+        let has_advanced_filters = !self.advanced_filter_fields.all_empty();
 
         if has_advanced_filters {
             self.apply_advanced_filter();

--- a/src/app/transaction_io.rs
+++ b/src/app/transaction_io.rs
@@ -84,8 +84,8 @@ impl App {
         );
     }
 
-    /// Resolve a path for comparison. The destination usually does not exist yet, so fall back to
-    /// canonicalizing the parent so relative paths and symlinked directories still compare equal.
+    /// The destination usually does not exist yet, so fall back to canonicalizing its parent to
+    /// keep relative paths and symlinked directories comparable.
     fn resolve_io_path(path: &Path) -> PathBuf {
         if let Ok(canonical) = path.canonicalize() {
             return canonical;
@@ -115,7 +115,7 @@ impl App {
         }
         let path = PathBuf::from(&path_str);
 
-        // save_transactions truncates whatever it opens, so refuse the live database outright.
+        // save_transactions truncates whatever it opens.
         if Self::resolve_io_path(&path) == Self::resolve_io_path(&self.database_path) {
             self.set_status_message(
                 "Error: that is the active database file. Choose a different export destination.",

--- a/src/events/add_edit_mode.rs
+++ b/src/events/add_edit_mode.rs
@@ -1,3 +1,4 @@
+use crate::app::fields::{AddEditField, FieldKey, FieldKind};
 use crate::app::state::{App, AppMode};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
@@ -18,12 +19,11 @@ pub fn handle_add_edit_mode(app: &mut App, key_event: KeyEvent) {
         }
         (KeyModifiers::NONE, KeyCode::Enter) => {
             // Toggle Type, trigger selection popups, or save transaction
-            match app.current_add_edit_field {
-                3 => app.toggle_transaction_type(), // Enter on Type field toggles it
-                4 => app.start_category_selection(), // Enter on Category field
-                5 => app.start_subcategory_selection(), // Enter on Subcategory field
-                _ => {
-                    // Enter on any other field: Save
+            match app.add_edit_fields.focused() {
+                AddEditField::TransactionType => app.toggle_transaction_type(),
+                AddEditField::Category => app.start_category_selection(),
+                AddEditField::Subcategory => app.start_subcategory_selection(),
+                AddEditField::Date | AddEditField::Description | AddEditField::Amount => {
                     if app.mode == AppMode::Adding {
                         app.add_transaction();
                     } else {
@@ -34,41 +34,55 @@ pub fn handle_add_edit_mode(app: &mut App, key_event: KeyEvent) {
         }
         (KeyModifiers::NONE, KeyCode::Up) => app.previous_add_edit_field(),
         (KeyModifiers::NONE, KeyCode::Down) => app.next_add_edit_field(),
-        (KeyModifiers::NONE, KeyCode::Left) => match app.current_add_edit_field {
-            0 => app.decrement_date(),
-            3 => app.toggle_transaction_type(),
-            _ => app.move_cursor_left(),
+        (KeyModifiers::NONE, KeyCode::Left) => match app.add_edit_fields.focused() {
+            AddEditField::Date => app.decrement_date(),
+            AddEditField::TransactionType => app.toggle_transaction_type(),
+            AddEditField::Description
+            | AddEditField::Amount
+            | AddEditField::Category
+            | AddEditField::Subcategory => app.move_cursor_left(),
         },
-        (KeyModifiers::NONE, KeyCode::Right) => match app.current_add_edit_field {
-            0 => app.increment_date(),
-            3 => app.toggle_transaction_type(),
-            _ => app.move_cursor_right(),
+        (KeyModifiers::NONE, KeyCode::Right) => match app.add_edit_fields.focused() {
+            AddEditField::Date => app.increment_date(),
+            AddEditField::TransactionType => app.toggle_transaction_type(),
+            AddEditField::Description
+            | AddEditField::Amount
+            | AddEditField::Category
+            | AddEditField::Subcategory => app.move_cursor_right(),
         },
-        (KeyModifiers::SHIFT, KeyCode::Left) if app.current_add_edit_field == 0 => {
+        (KeyModifiers::SHIFT, KeyCode::Left)
+            if app.add_edit_fields.focused() == AddEditField::Date =>
+        {
             app.decrement_month()
         }
-        (KeyModifiers::SHIFT, KeyCode::Right) if app.current_add_edit_field == 0 => {
+        (KeyModifiers::SHIFT, KeyCode::Right)
+            if app.add_edit_fields.focused() == AddEditField::Date =>
+        {
             app.increment_month()
         }
-        (KeyModifiers::NONE, KeyCode::Char(c)) => match app.current_add_edit_field {
-            0 if c == '+' || c == '=' => app.increment_date(),
-            0 if c == '-' => app.decrement_date(),
-            // Only allow digits for the date field (field 0)
-            0 if c.is_ascii_digit() => app.insert_char_at_cursor(c),
-            // Allow any character for other non-special fields (1, 2)
-            field if ![0, 3, 4, 5].contains(&field) => app.insert_char_at_cursor(c),
-            _ => {} // Ignore char input for fields 0 (non-digit), 3, 4, 5
-        },
-        (KeyModifiers::SHIFT, KeyCode::Char(c)) if app.current_add_edit_field == 1 => {
+        (KeyModifiers::NONE, KeyCode::Char(c)) => {
+            let field = app.add_edit_fields.focused();
+            match field.kind() {
+                FieldKind::Date if c == '+' || c == '=' => app.increment_date(),
+                FieldKind::Date if c == '-' => app.decrement_date(),
+                FieldKind::Date if c.is_ascii_digit() => app.insert_char_at_cursor(c),
+                FieldKind::Date => {}
+                kind if !kind.is_editable() => {}
+                _ => app.insert_char_at_cursor(c),
+            }
+        }
+        (KeyModifiers::SHIFT, KeyCode::Char(c))
+            if app.add_edit_fields.focused() == AddEditField::Description =>
+        {
             app.insert_char_at_cursor(c);
         }
         (KeyModifiers::NONE, KeyCode::Backspace)
-            if ![3, 4, 5].contains(&app.current_add_edit_field) =>
+            if app.add_edit_fields.focused().kind().is_editable() =>
         {
             app.delete_char_before_cursor();
         }
         (KeyModifiers::NONE, KeyCode::Delete)
-            if ![3, 4, 5].contains(&app.current_add_edit_field) =>
+            if app.add_edit_fields.focused().kind().is_editable() =>
         {
             app.delete_char_after_cursor();
         }

--- a/src/events/category_manager_mode.rs
+++ b/src/events/category_manager_mode.rs
@@ -1,3 +1,4 @@
+use crate::app::fields::{CategoryEditField, FieldKey, FieldKind};
 use crate::app::state::{App, AppMode};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
@@ -71,41 +72,45 @@ fn handle_category_editor(app: &mut App, key_event: KeyEvent) {
             app.previous_category_field()
         }
         (KeyCode::Enter, KeyModifiers::NONE) => {
-            if app.current_category_field == 0 {
+            if app.category_edit_fields.focused() == CategoryEditField::TransactionType {
                 app.toggle_category_transaction_type();
             } else {
                 app.save_category();
             }
         }
         (KeyCode::Left, KeyModifiers::NONE) => {
-            if app.current_category_field == 0 {
+            if app.category_edit_fields.focused() == CategoryEditField::TransactionType {
                 app.toggle_category_transaction_type();
             } else {
                 app.move_cursor_left();
             }
         }
         (KeyCode::Right, KeyModifiers::NONE) => {
-            if app.current_category_field == 0 {
+            if app.category_edit_fields.focused() == CategoryEditField::TransactionType {
                 app.toggle_category_transaction_type();
             } else {
                 app.move_cursor_right();
             }
         }
-        (KeyCode::Char(c), KeyModifiers::NONE) => match app.current_category_field {
-            0 => {}
-            4 if c.is_ascii_digit() || c == '.' => app.insert_char_at_cursor(c),
-            1..=3 => app.insert_char_at_cursor(c),
+        (KeyCode::Char(c), KeyModifiers::NONE) => match app.category_edit_fields.focused().kind() {
+            FieldKind::Amount if c.is_ascii_digit() || c == '.' => app.insert_char_at_cursor(c),
+            FieldKind::Amount => {}
+            FieldKind::Text => app.insert_char_at_cursor(c),
             _ => {}
         },
         (KeyCode::Char(c), KeyModifiers::SHIFT)
-            if (1..=3).contains(&app.current_category_field) =>
+            if app.category_edit_fields.focused().kind() == FieldKind::Text =>
         {
             app.insert_char_at_cursor(c);
         }
-        (KeyCode::Backspace, KeyModifiers::NONE) if app.current_category_field != 0 => {
+        (KeyCode::Backspace, KeyModifiers::NONE)
+            if app.category_edit_fields.focused().kind().is_editable() =>
+        {
             app.delete_char_before_cursor();
         }
-        (KeyCode::Delete, KeyModifiers::NONE) if app.current_category_field != 0 => {
+        (KeyCode::Delete, KeyModifiers::NONE)
+            if app.category_edit_fields.focused().kind().is_editable() =>
+        {
             app.delete_char_after_cursor();
         }
         _ => {}

--- a/src/events/filter_mode.rs
+++ b/src/events/filter_mode.rs
@@ -1,3 +1,4 @@
+use crate::app::fields::{AdvancedFilterField, FieldKey, FieldKind};
 use crate::app::state::{App, AppMode};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
@@ -45,43 +46,65 @@ fn handle_advanced_filtering(app: &mut App, key_event: KeyEvent) {
     match (key_event.modifiers, key_event.code) {
         (KeyModifiers::CONTROL, KeyCode::Char('r')) => app.reset_all_filters(),
         (KeyModifiers::NONE, KeyCode::Esc) => app.cancel_advanced_filtering(),
-        (KeyModifiers::NONE, KeyCode::Enter) => match app.current_advanced_filter_field {
-            3 => app.start_advanced_category_selection(),
-            4 => app.start_advanced_subcategory_selection(),
-            _ => app.finish_advanced_filtering(),
+        (KeyModifiers::NONE, KeyCode::Enter) => match app.advanced_filter_fields.focused() {
+            AdvancedFilterField::Category => app.start_advanced_category_selection(),
+            AdvancedFilterField::Subcategory => app.start_advanced_subcategory_selection(),
+            AdvancedFilterField::DateFrom
+            | AdvancedFilterField::DateTo
+            | AdvancedFilterField::Description
+            | AdvancedFilterField::TransactionType
+            | AdvancedFilterField::Recurring
+            | AdvancedFilterField::AmountFrom
+            | AdvancedFilterField::AmountTo => app.finish_advanced_filtering(),
         },
         (KeyModifiers::NONE, KeyCode::Tab) => app.next_advanced_filter_field(),
         (KeyModifiers::NONE, KeyCode::BackTab) => app.previous_advanced_filter_field(),
         (KeyModifiers::NONE, KeyCode::Up) => app.previous_advanced_filter_field(),
         (KeyModifiers::NONE, KeyCode::Down) => app.next_advanced_filter_field(),
-        (KeyModifiers::NONE, KeyCode::Left) => match app.current_advanced_filter_field {
-            0 | 1 => app.decrement_advanced_date(),
-            5 => app.toggle_advanced_transaction_type(),
-            6 => app.toggle_advanced_recurring(),
-            _ => app.move_cursor_left(),
-        },
-        (KeyModifiers::NONE, KeyCode::Right) => match app.current_advanced_filter_field {
-            0 | 1 => app.increment_advanced_date(),
-            5 => app.toggle_advanced_transaction_type(),
-            6 => app.toggle_advanced_recurring(),
-            _ => app.move_cursor_right(),
-        },
-        (KeyModifiers::SHIFT, KeyCode::Left) => match app.current_advanced_filter_field {
-            0 | 1 => app.decrement_advanced_month(),
-            _ => {}
-        },
-        (KeyModifiers::SHIFT, KeyCode::Right) => match app.current_advanced_filter_field {
-            0 | 1 => app.increment_advanced_month(),
-            _ => {}
-        },
-        (KeyModifiers::NONE, KeyCode::Char(c)) => match app.current_advanced_filter_field {
-            0 | 1 if c == '+' || c == '=' => app.increment_advanced_date(),
-            0 | 1 if c == '-' => app.decrement_advanced_date(),
-            _ => {
-                app.clear_simple_filter_field_only();
-                app.insert_char_at_cursor(c);
+        (KeyModifiers::NONE, KeyCode::Left) => match app.advanced_filter_fields.focused() {
+            AdvancedFilterField::DateFrom | AdvancedFilterField::DateTo => {
+                app.decrement_advanced_date()
             }
+            AdvancedFilterField::TransactionType => app.toggle_advanced_transaction_type(),
+            AdvancedFilterField::Recurring => app.toggle_advanced_recurring(),
+            AdvancedFilterField::Description
+            | AdvancedFilterField::Category
+            | AdvancedFilterField::Subcategory
+            | AdvancedFilterField::AmountFrom
+            | AdvancedFilterField::AmountTo => app.move_cursor_left(),
         },
+        (KeyModifiers::NONE, KeyCode::Right) => match app.advanced_filter_fields.focused() {
+            AdvancedFilterField::DateFrom | AdvancedFilterField::DateTo => {
+                app.increment_advanced_date()
+            }
+            AdvancedFilterField::TransactionType => app.toggle_advanced_transaction_type(),
+            AdvancedFilterField::Recurring => app.toggle_advanced_recurring(),
+            AdvancedFilterField::Description
+            | AdvancedFilterField::Category
+            | AdvancedFilterField::Subcategory
+            | AdvancedFilterField::AmountFrom
+            | AdvancedFilterField::AmountTo => app.move_cursor_right(),
+        },
+        (KeyModifiers::SHIFT, KeyCode::Left)
+            if app.advanced_filter_fields.focused().kind() == FieldKind::Date =>
+        {
+            app.decrement_advanced_month()
+        }
+        (KeyModifiers::SHIFT, KeyCode::Right)
+            if app.advanced_filter_fields.focused().kind() == FieldKind::Date =>
+        {
+            app.increment_advanced_month()
+        }
+        (KeyModifiers::NONE, KeyCode::Char(c)) => {
+            match app.advanced_filter_fields.focused().kind() {
+                FieldKind::Date if c == '+' || c == '=' => app.increment_advanced_date(),
+                FieldKind::Date if c == '-' => app.decrement_advanced_date(),
+                _ => {
+                    app.clear_simple_filter_field_only();
+                    app.insert_char_at_cursor(c);
+                }
+            }
+        }
         (KeyModifiers::SHIFT, KeyCode::Char(c)) => {
             app.clear_simple_filter_field_only();
             app.insert_char_at_cursor(c);

--- a/src/events/recurring_mode.rs
+++ b/src/events/recurring_mode.rs
@@ -1,12 +1,13 @@
+use crate::app::fields::RecurringField;
 use crate::app::state::App;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 pub fn handle_recurring_mode(app: &mut App, key_event: KeyEvent) {
     match (key_event.modifiers, key_event.code) {
         (KeyModifiers::NONE, KeyCode::Esc) => app.exit_recurring_settings(true),
-        (KeyModifiers::NONE, KeyCode::Enter) => match app.current_recurring_field {
-            1 => app.start_frequency_selection(),
-            _ => app.save_recurring_settings(),
+        (KeyModifiers::NONE, KeyCode::Enter) => match app.recurring_settings_fields.focused() {
+            RecurringField::Frequency => app.start_frequency_selection(),
+            RecurringField::IsRecurring | RecurringField::EndDate => app.save_recurring_settings(),
         },
         (KeyModifiers::NONE, KeyCode::Tab) | (KeyModifiers::NONE, KeyCode::Down) => {
             app.next_recurring_field()
@@ -14,29 +15,39 @@ pub fn handle_recurring_mode(app: &mut App, key_event: KeyEvent) {
         (KeyModifiers::NONE, KeyCode::BackTab) | (KeyModifiers::NONE, KeyCode::Up) => {
             app.previous_recurring_field()
         }
-        (KeyModifiers::NONE, KeyCode::Left) => match app.current_recurring_field {
-            0 => app.toggle_recurring_enabled(),
-            2 => app.decrement_date_recurring(),
-            _ => {}
+        (KeyModifiers::NONE, KeyCode::Left) => match app.recurring_settings_fields.focused() {
+            RecurringField::IsRecurring => app.toggle_recurring_enabled(),
+            RecurringField::EndDate => app.decrement_date_recurring(),
+            RecurringField::Frequency => {}
         },
-        (KeyModifiers::NONE, KeyCode::Right) => match app.current_recurring_field {
-            0 => app.toggle_recurring_enabled(),
-            2 => app.increment_date_recurring(),
-            _ => {}
+        (KeyModifiers::NONE, KeyCode::Right) => match app.recurring_settings_fields.focused() {
+            RecurringField::IsRecurring => app.toggle_recurring_enabled(),
+            RecurringField::EndDate => app.increment_date_recurring(),
+            RecurringField::Frequency => {}
         },
-        (KeyModifiers::SHIFT, KeyCode::Left) if app.current_recurring_field == 2 => {
+        (KeyModifiers::SHIFT, KeyCode::Left)
+            if app.recurring_settings_fields.focused() == RecurringField::EndDate =>
+        {
             app.decrement_month_recurring();
         }
-        (KeyModifiers::SHIFT, KeyCode::Right) if app.current_recurring_field == 2 => {
+        (KeyModifiers::SHIFT, KeyCode::Right)
+            if app.recurring_settings_fields.focused() == RecurringField::EndDate =>
+        {
             app.increment_month_recurring();
         }
-        (KeyModifiers::NONE, KeyCode::Char(c)) => match app.current_recurring_field {
-            2 if c == '+' || c == '=' => app.increment_date_recurring(),
-            2 if c == '-' => app.decrement_date_recurring(),
-            2 if c.is_ascii_digit() => app.insert_char_recurring(c),
-            _ => {}
-        },
-        (KeyModifiers::NONE, KeyCode::Backspace) if app.current_recurring_field == 2 => {
+        (KeyModifiers::NONE, KeyCode::Char(c))
+            if app.recurring_settings_fields.focused() == RecurringField::EndDate =>
+        {
+            match c {
+                '+' | '=' => app.increment_date_recurring(),
+                '-' => app.decrement_date_recurring(),
+                _ if c.is_ascii_digit() => app.insert_char_recurring(c),
+                _ => {}
+            }
+        }
+        (KeyModifiers::NONE, KeyCode::Backspace)
+            if app.recurring_settings_fields.focused() == RecurringField::EndDate =>
+        {
             app.delete_char_recurring();
         }
         _ => {}

--- a/src/events/selection_mode.rs
+++ b/src/events/selection_mode.rs
@@ -1,3 +1,4 @@
+use crate::app::fields::RecurringField;
 use crate::app::state::{App, AppMode};
 use crossterm::event::{KeyCode, KeyEvent};
 
@@ -49,7 +50,7 @@ fn handle_recurrence_frequency_selection(app: &mut App, key_event: KeyEvent) {
             if let Some(selected) = app.selection_list_state.selected()
                 && let Some(frequency) = app.current_selection_list.get(selected)
             {
-                app.recurring_settings_fields[1] = frequency.clone();
+                app.recurring_settings_fields[RecurringField::Frequency] = frequency.clone();
             }
             app.mode = AppMode::RecurringSettings;
         }

--- a/src/ui/category_manager.rs
+++ b/src/ui/category_manager.rs
@@ -1,3 +1,4 @@
+use crate::app::fields::{CategoryEditField, FieldKey, FieldKind};
 use crate::app::state::App;
 use ratatui::prelude::*;
 use ratatui::widgets::*;
@@ -101,35 +102,27 @@ pub fn render_category_filter_input(f: &mut Frame, app: &App, area: Rect) {
 }
 
 pub fn render_category_editor(f: &mut Frame, app: &App, area: Rect) {
-    let income_category = app.category_edit_fields[0].eq_ignore_ascii_case("income");
-    let field_definitions = [
-        ("Transaction Type", "(Left/Right or Enter to toggle)"),
-        ("Category", ""),
-        ("Subcategory", "(Optional)"),
-        ("Tag", "(Optional)"),
-        (
-            "Target Budget",
-            if income_category {
-                "(Expense categories only)"
-            } else {
-                "(Optional, positive number)"
-            },
-        ),
-    ];
+    let income_category =
+        app.category_edit_fields[CategoryEditField::TransactionType].eq_ignore_ascii_case("income");
+    let focused_field = app.category_edit_fields.focused();
     let input_widgets: Vec<_> = app
         .category_edit_fields
         .iter()
-        .zip(field_definitions.iter())
-        .enumerate()
-        .map(|(index, (text, (base_title, hint)))| {
-            let is_focused = app.current_category_field == index;
-            let title = format!("{} {}", base_title, hint).trim_end().to_string();
-            let content = if index == 0 {
+        .map(|(field, text)| {
+            let is_focused = field == focused_field;
+            let hint = if field == CategoryEditField::TargetBudget && income_category {
+                "(Expense categories only)"
+            } else {
+                field.hint()
+            };
+            let title = format!("{} {}", field.label(), hint).trim_end().to_string();
+            let content = if field.kind() == FieldKind::Toggle {
                 Span::styled(
                     format!(" < {} > ", text),
                     Style::default().fg(Color::White).bold(),
                 )
-            } else if index == 4 && income_category && text.is_empty() {
+            } else if field == CategoryEditField::TargetBudget && income_category && text.is_empty()
+            {
                 Span::styled(
                     "Expense categories only",
                     Style::default().fg(Color::DarkGray),
@@ -158,8 +151,8 @@ pub fn render_category_editor(f: &mut Frame, app: &App, area: Rect) {
     let max_visible_fields = ((available_height / field_height) as usize)
         .max(1)
         .min(total_fields);
-    let scroll_offset = app
-        .current_category_field
+    let scroll_offset = focused_field
+        .index()
         .saturating_sub(max_visible_fields - 1)
         .min(total_fields - max_visible_fields);
 
@@ -196,9 +189,9 @@ pub fn render_category_editor(f: &mut Frame, app: &App, area: Rect) {
         .borders(Borders::ALL);
     f.render_widget(form_block, area);
 
-    if app.current_category_field != 0 {
-        let field_idx = app.current_category_field;
-        let text = &app.category_edit_fields[field_idx];
+    if focused_field.kind().is_editable() {
+        let field_idx = focused_field.index();
+        let text = &app.category_edit_fields[focused_field];
         let cursor_byte_idx = app.category_edit_cursor.min(text.len());
         let visual_cursor = text[..cursor_byte_idx].chars().count() as u16;
 

--- a/src/ui/filter.rs
+++ b/src/ui/filter.rs
@@ -1,3 +1,4 @@
+use crate::app::fields::{FieldKey, FieldKind};
 use crate::app::state::App;
 use ratatui::prelude::*;
 use ratatui::widgets::*;
@@ -15,32 +16,15 @@ pub fn render_filter_input(f: &mut Frame, app: &App, area: Rect) {
 }
 
 pub fn render_advanced_filter_form(f: &mut Frame, app: &App, area: Rect) {
-    let field_definitions = [
-        (
-            "Date From (YYYY-MM-DD)",
-            "(◀/▶ or +/- days, Shift+◀/▶ months (jumps to today if empty), Digits to enter)",
-        ),
-        (
-            "Date To (YYYY-MM-DD)",
-            "(◀/▶ or +/- days, Shift+◀/▶ months (jumps to today if empty), Digits to enter)",
-        ),
-        ("Description", ""),
-        ("Category", "(Enter to select)"),
-        ("Subcategory", "(Enter to select)"),
-        ("Type", "(◀/▶)"),
-        ("Recurring", "(◀/▶)"),
-        ("Amount From", ""),
-        ("Amount To", ""),
-    ];
+    let focused_field = app.advanced_filter_fields.focused();
     let widgets: Vec<_> = app
         .advanced_filter_fields
         .iter()
-        .zip(field_definitions.iter())
-        .enumerate()
-        .map(|(i, (text, (title, hint)))| {
-            let focused = app.current_advanced_filter_field == i;
-            let label = format!("{} {}", title, hint).trim_end().to_string();
-            let content = if i == 5 || i == 6 {
+        .map(|(field, text)| {
+            let label = format!("{} {}", field.label(), field.hint())
+                .trim_end()
+                .to_string();
+            let content = if field.kind() == FieldKind::Toggle {
                 Span::styled(
                     format!(" < {} > ", text),
                     Style::default().fg(Color::White).bold(),
@@ -54,7 +38,7 @@ pub fn render_advanced_filter_form(f: &mut Frame, app: &App, area: Rect) {
                     Block::default()
                         .borders(Borders::ALL)
                         .title(label)
-                        .border_style(if focused {
+                        .border_style(if field == focused_field {
                             Style::default().fg(Color::Yellow)
                         } else {
                             Style::default()
@@ -67,8 +51,8 @@ pub fn render_advanced_filter_form(f: &mut Frame, app: &App, area: Rect) {
     let total = widgets.len();
     let avail = area.height.saturating_sub(margin * 2);
     let maxv = ((avail / fh) as usize).max(1).min(total);
-    let offset = app
-        .current_advanced_filter_field
+    let offset = focused_field
+        .index()
         .saturating_sub(maxv - 1)
         .min(total - maxv);
     let mut cons = vec![Constraint::Length(fh); maxv];
@@ -87,9 +71,9 @@ pub fn render_advanced_filter_form(f: &mut Frame, app: &App, area: Rect) {
             .title("Advanced Filters"),
         area,
     );
-    if ![3, 4, 5, 6].contains(&app.current_advanced_filter_field) {
-        let field_idx = app.current_advanced_filter_field;
-        let text = &app.advanced_filter_fields[field_idx];
+    if focused_field.kind().is_editable() {
+        let field_idx = focused_field.index();
+        let text = &app.advanced_filter_fields[focused_field];
         let cursor_pos = app.advanced_filter_cursor.min(text.len());
         // Calculate visual cursor position (accounting for potential multi-byte chars)
         let visual_cursor = text[..cursor_pos].chars().count() as u16;

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -3,9 +3,8 @@ use ratatui::style::Color;
 use rust_decimal::{Decimal, RoundingStrategy};
 
 pub fn format_amount(amount: &Decimal) -> String {
-    // Format straight off the Decimal: going through f64 first would round monetary values
-    // against their binary approximation rather than their stored decimal digits. Half-away-from-
-    // zero is the usual currency convention, where round_dp alone would round half to even.
+    // Rounding via f64 would go off the binary approximation, not the stored decimal digits.
+    // round_dp alone rounds half to even, so ask for the usual currency convention instead.
     let rounded = amount.round_dp_with_strategy(2, RoundingStrategy::MidpointAwayFromZero);
     let s = format!("{:.2}", rounded.abs());
     let (int_part, frac_part) = s.split_once('.').unwrap_or((s.as_str(), "00"));

--- a/src/ui/recurring.rs
+++ b/src/ui/recurring.rs
@@ -1,3 +1,4 @@
+use crate::app::fields::{FieldKey, FieldKind};
 use crate::app::state::App;
 use ratatui::{
     Frame,
@@ -8,57 +9,35 @@ use ratatui::{
 };
 
 pub fn render_recurring_settings(f: &mut Frame, app: &App, area: Rect) {
-    // Field definitions with titles and hints
-    let field_definitions = [
-        ("Is Recurring", "(◀/▶ to toggle)"),
-        ("Frequency", "(Enter to select)"),
-        (
-            "End Date (YYYY-MM-DD)",
-            "(Optional - ◀/▶ days, Shift+◀/▶ months, jumps to today if empty)",
-        ),
-    ];
-
+    let focused_field = app.recurring_settings_fields.focused();
     let input_widgets: Vec<_> = app
         .recurring_settings_fields
         .iter()
-        .zip(field_definitions.iter())
-        .enumerate()
-        .map(|(i, (text, (base_title, hint)))| {
-            let is_focused = app.current_recurring_field == i;
-            let title = format!("{} {}", base_title, hint).trim_end().to_string();
+        .map(|(field, text)| {
+            let is_focused = field == focused_field;
+            let title = format!("{} {}", field.label(), field.hint())
+                .trim_end()
+                .to_string();
 
-            let content = match i {
-                0 => {
-                    // Is Recurring field - show as toggle
-                    Span::styled(
-                        format!(" < {} > ", text),
-                        Style::default()
-                            .fg(Color::White)
-                            .add_modifier(Modifier::BOLD),
-                    )
-                }
-                1 => {
-                    // Frequency field - show as selection
-                    Span::styled(
-                        format!("  {}  ", text),
-                        Style::default()
-                            .fg(Color::White)
-                            .add_modifier(Modifier::BOLD),
-                    )
-                }
-                2 => {
-                    // End Date field - show as text input
-                    if text.is_empty() {
-                        Span::styled(
-                            " (Optional - leave empty for no end date) ",
-                            Style::default()
-                                .fg(Color::DarkGray)
-                                .add_modifier(Modifier::ITALIC),
-                        )
-                    } else {
-                        Span::raw(text.as_str())
-                    }
-                }
+            let content = match field.kind() {
+                FieldKind::Toggle => Span::styled(
+                    format!(" < {} > ", text),
+                    Style::default()
+                        .fg(Color::White)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                FieldKind::Selection => Span::styled(
+                    format!("  {}  ", text),
+                    Style::default()
+                        .fg(Color::White)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                _ if text.is_empty() => Span::styled(
+                    " (Optional - leave empty for no end date) ",
+                    Style::default()
+                        .fg(Color::DarkGray)
+                        .add_modifier(Modifier::ITALIC),
+                ),
                 _ => Span::raw(text.as_str()),
             };
 
@@ -85,8 +64,8 @@ pub fn render_recurring_settings(f: &mut Frame, app: &App, area: Rect) {
     let max_visible_fields = ((available_height / field_height) as usize)
         .max(1)
         .min(total_fields);
-    let scroll_offset = app
-        .current_recurring_field
+    let scroll_offset = focused_field
+        .index()
         .saturating_sub(max_visible_fields - 1)
         .min(total_fields - max_visible_fields);
 
@@ -119,10 +98,9 @@ pub fn render_recurring_settings(f: &mut Frame, app: &App, area: Rect) {
         .borders(Borders::ALL);
     f.render_widget(form_block, area);
 
-    // Set cursor position for the end date field (field 2), adjusting for scrolling
-    if app.current_recurring_field == 2 {
-        let field_idx = app.current_recurring_field;
-        let text_len = app.recurring_settings_fields[field_idx].len() as u16;
+    if focused_field.kind().is_editable() {
+        let field_idx = focused_field.index();
+        let text_len = app.recurring_settings_fields[focused_field].len() as u16;
         if field_idx >= scroll_offset && field_idx < scroll_offset + max_visible_fields {
             let visible_idx = field_idx - scroll_offset;
             if let Some(chunk) = form_chunks.get(visible_idx) {

--- a/src/ui/transaction_form.rs
+++ b/src/ui/transaction_form.rs
@@ -1,29 +1,19 @@
+use crate::app::fields::{FieldKey, FieldKind};
 use crate::app::state::App;
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 
 pub fn render_transaction_form(f: &mut Frame, app: &App, area: Rect) {
-    // Field titles and hints
-    let field_definitions = [
-        (
-            "Date (YYYY-MM-DD)",
-            "(◀/▶ or +/- for days, Shift+◀/▶ for months, Digits to enter)",
-        ),
-        ("Description", ""),
-        ("Amount", ""),
-        ("Type", "(◀/▶ or Enter to toggle)"),
-        ("Category", "(Enter to select)"),
-        ("Subcategory", "(Enter to select)"),
-    ];
+    let focused_field = app.add_edit_fields.focused();
     let input_widgets: Vec<_> = app
         .add_edit_fields
         .iter()
-        .zip(field_definitions.iter())
-        .enumerate()
-        .map(|(i, (text, (base_title, hint)))| {
-            let is_focused = app.current_add_edit_field == i;
-            let title = format!("{} {}", base_title, hint).trim_end().to_string();
-            let content = if i == 3 {
+        .map(|(field, text)| {
+            let is_focused = field == focused_field;
+            let title = format!("{} {}", field.label(), field.hint())
+                .trim_end()
+                .to_string();
+            let content = if field.kind() == FieldKind::Toggle {
                 Span::styled(
                     format!(" < {} > ", text),
                     Style::default().fg(Color::White).bold(),
@@ -54,8 +44,8 @@ pub fn render_transaction_form(f: &mut Frame, app: &App, area: Rect) {
     let max_visible_fields = ((available_height / field_height) as usize)
         .max(1)
         .min(total_fields);
-    let scroll_offset = app
-        .current_add_edit_field
+    let scroll_offset = focused_field
+        .index()
         .saturating_sub(max_visible_fields - 1)
         .min(total_fields - max_visible_fields);
 
@@ -92,9 +82,9 @@ pub fn render_transaction_form(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(form_block, area);
 
     // Set cursor position for editable text fields, adjusting for scrolling
-    if ![3, 4, 5].contains(&app.current_add_edit_field) {
-        let field_idx = app.current_add_edit_field;
-        let text = &app.add_edit_fields[field_idx];
+    if focused_field.kind().is_editable() {
+        let field_idx = focused_field.index();
+        let text = &app.add_edit_fields[focused_field];
         let cursor_byte_idx = app.add_edit_cursor.min(text.len());
         let visual_cursor = text[..cursor_byte_idx].chars().count() as u16;
 


### PR DESCRIPTION
Replace numeric field indices with typed enums and `FieldSet` abstractions across transaction, category, filter, and recurring forms.

WIP, more testing needed before landing this anywhere.