### PR TITLE
Add help and version command-line options

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,34 @@ use ratatui::prelude::{CrosstermBackend, Terminal};
 use std::io::stdout;
 use std::result::Result as StdResult;
 
+const HELP: &str = concat!(
+    "A terminal app for tracking your personal budget.\n\n",
+    "Usage: ",
+    env!("CARGO_BIN_NAME"),
+    " [OPTIONS]\n\n",
+    "Options:\n",
+    "  -h, --help     Print this help\n",
+    "  -V, --version  Print version\n\n",
+    "Run with no arguments to start the app. Press Ctrl+H inside it for the keybindings."
+);
+
 fn main() -> StdResult<(), Box<dyn std::error::Error>> {
+    match std::env::args().nth(1).as_deref() {
+        None => {}
+        Some("-h" | "--help") => {
+            println!("{HELP}");
+            return Ok(());
+        }
+        Some("-V" | "--version") => {
+            println!("{} {}", env!("CARGO_BIN_NAME"), env!("CARGO_PKG_VERSION"));
+            return Ok(());
+        }
+        Some(other) => {
+            eprintln!("unrecognized argument: {other}\n\n{HELP}");
+            std::process::exit(2);
+        }
+    }
+
     enable_raw_mode()?;
     stdout()
         .execute(EnterAlternateScreen)?


### PR DESCRIPTION
Add command line arguments like `--help` and `--version` to prepare the app to be submittable to some package managers