### PR TITLE
Add inline budget target editing

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -54,7 +54,11 @@ Forecast occurrences are derived in memory like every other generated occurrence
 
 **Category summary (`c`)** breaks down each month by category. `Enter` expands or collapses a month, `PageUp`/`PageDown` move between months, `←`/`→` between years.
 
-**Budget view (`b`)** compares spending against your monthly target and any per-category budgets. `↑`/`↓` move between categories, `←`/`→` between months, `Shift+←`/`Shift+→` between years. Press `c` to open the [category catalog](#the-category-catalog) and adjust per-category budgets without leaving the view.
+**Budget view (`b`)** compares spending against your monthly target and any per-category budgets. `↑`/`↓` move between categories, `←`/`→` between months, `Shift+←`/`Shift+→` between years. Press `e` on a row to change that category's target budget in place. The popup starts on
+the current amount; `Enter` saves, `Esc` cancels, and an empty amount clears the budget, which also
+drops the category from the table since only budgeted categories are listed. Press `c` to open the
+[category catalog](#the-category-catalog), which is where you set a budget on a category that
+doesn't have one yet.
 
 ## The category catalog
 

--- a/src/app/budget.rs
+++ b/src/app/budget.rs
@@ -1,6 +1,7 @@
 use super::state::{App, AppMode, BudgetCategoryComparison};
+use crate::db::category_store::CategoryStore;
 use crate::model::{CategoryRecord, TransactionType};
-use chrono::Datelike;
+use chrono::{Datelike, Duration};
 use rust_decimal::Decimal;
 
 fn normalize_budget_key(category: &str, subcategory: &str) -> (String, String) {
@@ -15,6 +16,14 @@ fn normalize_budget_key(category: &str, subcategory: &str) -> (String, String) {
     (normalized_category, subcategory.to_string())
 }
 
+fn record_label(record: &CategoryRecord) -> String {
+    if record.subcategory.trim().is_empty() {
+        record.category.clone()
+    } else {
+        format!("{} / {}", record.category, record.subcategory)
+    }
+}
+
 fn comparison_from_record(
     record: &CategoryRecord,
     actual_expense: Decimal,
@@ -27,6 +36,7 @@ fn comparison_from_record(
     let (category, subcategory) = normalize_budget_key(&record.category, &record.subcategory);
 
     Some(BudgetCategoryComparison {
+        id: record.id,
         category,
         subcategory,
         target_budget,
@@ -252,6 +262,101 @@ impl App {
         let comparisons = self.current_budget_category_comparisons();
         let selected = self.budget_table_state.selected().unwrap_or(0);
         comparisons.get(selected).cloned()
+    }
+
+    // --- Target budget editing ---
+
+    pub(crate) fn start_editing_budget_target(&mut self) {
+        let Some(comparison) = self.selected_budget_category_comparison() else {
+            let message = if self.selected_budget_month.is_none() {
+                "No month selected."
+            } else {
+                "No category budgets yet. Press c to set one in the catalog."
+            };
+            self.set_status_message(message, None);
+            return;
+        };
+
+        self.mode = AppMode::BudgetCategoryEditor;
+        self.budget_edit_category_id = Some(comparison.id);
+        self.budget_edit_input = format!("{:.2}", comparison.target_budget);
+        self.budget_edit_cursor = self.budget_edit_input.len();
+        self.clear_status_message();
+    }
+
+    pub(crate) fn cancel_budget_target_edit(&mut self) {
+        self.mode = AppMode::Budget;
+        self.budget_edit_category_id = None;
+        self.budget_edit_input.clear();
+        self.budget_edit_cursor = 0;
+        self.set_status_message("Budget edit cancelled.", Some(Duration::seconds(3)));
+    }
+
+    pub(crate) fn budget_edit_label(&self) -> Option<String> {
+        self.budget_edit_record().map(record_label)
+    }
+
+    fn budget_edit_record(&self) -> Option<&CategoryRecord> {
+        let id = self.budget_edit_category_id?;
+        self.category_records.iter().find(|record| record.id == id)
+    }
+
+    pub(crate) fn save_budget_target(&mut self) {
+        let Some(record) = self.budget_edit_record().cloned() else {
+            self.cancel_budget_target_edit();
+            return;
+        };
+
+        let input = self.budget_edit_input.trim();
+        // Clearing it also drops the row from this table.
+        let target_budget = if input.is_empty() {
+            None
+        } else {
+            match crate::validation::validate_amount_string(input) {
+                Ok(amount) => Some(amount),
+                Err(message) => {
+                    self.set_status_message(format!("Error: {}", message), None);
+                    return;
+                }
+            }
+        };
+
+        let mut draft = record.to_draft();
+        draft.target_budget = target_budget;
+
+        if let Err(err) = self.category_store().update(record.id, &draft) {
+            self.set_status_message(format!("Error saving budget: {}", err), None);
+            return;
+        }
+
+        if let Err(err) = self.reload_categories_from_store() {
+            self.set_status_message(format!("Budget saved, but refresh failed: {}", err), None);
+            return;
+        }
+
+        self.mode = AppMode::Budget;
+        self.budget_edit_category_id = None;
+        self.budget_edit_input.clear();
+        self.budget_edit_cursor = 0;
+        self.select_budget_category(record.id);
+
+        let label = record_label(&record);
+        let message = match target_budget {
+            Some(amount) => format!("Budget for {} set to {:.2}.", label, amount),
+            None => format!("Budget for {} cleared.", label),
+        };
+        self.set_status_message(message, Some(Duration::seconds(3)));
+    }
+
+    fn select_budget_category(&mut self, id: i64) {
+        let comparisons = self.current_budget_category_comparisons();
+        match comparisons
+            .iter()
+            .position(|comparison| comparison.id == id)
+        {
+            Some(index) => self.budget_table_state.select(Some(index)),
+            None => self.clamp_budget_selection(comparisons.len()),
+        }
     }
 
     pub(crate) fn budget_category_monthly_expenses(

--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -336,6 +336,14 @@ pub fn get_help_for_mode(mode: AppMode) -> Vec<KeyBindingInfo> {
             KeyBindingInfo::new("←/→", "Change Month", "Navigation", None),
             KeyBindingInfo::new("Shift+←/→", "Change Year", "Navigation", None),
             KeyBindingInfo::new(
+                "e",
+                "Edit Target Budget",
+                "Actions",
+                Some(
+                    "Change the target budget of the selected category right here. Leaving the amount empty removes the budget, which also drops the category from this table.",
+                ),
+            ),
+            KeyBindingInfo::new(
                 "c",
                 "Manage Categories",
                 "Actions",
@@ -344,6 +352,19 @@ pub fn get_help_for_mode(mode: AppMode) -> Vec<KeyBindingInfo> {
                 ),
             ),
             KeyBindingInfo::new("q/Esc", "Back to Transactions", "Actions", None),
+            KeyBindingInfo::new("Ctrl+H", "Show Keybindings Help", "System", None),
+        ],
+        AppMode::BudgetCategoryEditor => vec![
+            KeyBindingInfo::new("0-9/.", "Type the amount", "Input", None),
+            KeyBindingInfo::new("←/→", "Move cursor", "Navigation", None),
+            KeyBindingInfo::new("Bksp/Del", "Delete character", "Input", None),
+            KeyBindingInfo::new(
+                "Enter",
+                "Save budget",
+                "Actions",
+                Some("An empty amount clears the budget for this category."),
+            ),
+            KeyBindingInfo::new("Esc", "Cancel", "Actions", None),
             KeyBindingInfo::new("Ctrl+H", "Show Keybindings Help", "System", None),
         ],
         AppMode::Settings => vec![

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -41,6 +41,11 @@ impl App {
                     field.kind(),
                 ))
             }
+            AppMode::BudgetCategoryEditor => Some((
+                &mut self.budget_edit_input,
+                &mut self.budget_edit_cursor,
+                FieldKind::Amount,
+            )),
             AppMode::LedgerEditor => Some((
                 &mut self.ledger_name_input,
                 &mut self.ledger_name_cursor,

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -39,6 +39,7 @@ pub enum AppMode {
     SelectingSubcategory,
     CategorySummary,
     Budget,
+    BudgetCategoryEditor,
     Settings,
     RecurringSettings,
     SelectingRecurrenceFrequency,
@@ -64,6 +65,7 @@ pub enum CategorySummaryItem {
 
 #[derive(Debug, Clone)]
 pub struct BudgetCategoryComparison {
+    pub id: i64,
     pub category: String,
     pub subcategory: String,
     pub target_budget: Decimal,
@@ -120,6 +122,9 @@ pub struct App {
     pub(crate) budget_year_index: usize,
     pub(crate) selected_budget_month: Option<u32>,
     pub(crate) budget_table_state: TableState,
+    pub(crate) budget_edit_category_id: Option<i64>,
+    pub(crate) budget_edit_input: String,
+    pub(crate) budget_edit_cursor: usize,
     // Settings form state
     pub(crate) settings_state: crate::app::settings_types::SettingsState,
     // Category catalog state
@@ -342,6 +347,9 @@ impl App {
             budget_year_index: 0,
             selected_budget_month: None,
             budget_table_state: TableState::default(),
+            budget_edit_category_id: None,
+            budget_edit_input: String::new(),
+            budget_edit_cursor: 0,
             settings_state: crate::app::settings_types::SettingsState::default(),
             category_table_state: TableState::default(),
             filtered_category_indices: initial_filtered_category_indices,

--- a/src/events/budget_mode.rs
+++ b/src/events/budget_mode.rs
@@ -2,8 +2,14 @@ use crate::app::state::{App, AppMode};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 pub fn handle_budget_mode(app: &mut App, key_event: KeyEvent) {
+    if app.mode == AppMode::BudgetCategoryEditor {
+        handle_budget_target_editor(app, key_event);
+        return;
+    }
+
     match (key_event.code, key_event.modifiers) {
         (KeyCode::Char('q'), _) | (KeyCode::Esc, _) => app.exit_budget_mode(),
+        (KeyCode::Char('e'), KeyModifiers::NONE) => app.start_editing_budget_target(),
         (KeyCode::Char('c'), KeyModifiers::NONE) => app.open_category_catalog(AppMode::Budget),
         (KeyCode::Down, KeyModifiers::NONE) => app.next_budget_category(),
         (KeyCode::Up, KeyModifiers::NONE) => app.previous_budget_category(),
@@ -11,6 +17,19 @@ pub fn handle_budget_mode(app: &mut App, key_event: KeyEvent) {
         (KeyCode::Left, KeyModifiers::NONE) => app.previous_budget_month(),
         (KeyCode::Right, KeyModifiers::SHIFT) => app.next_budget_year(),
         (KeyCode::Left, KeyModifiers::SHIFT) => app.previous_budget_year(),
+        _ => {}
+    }
+}
+
+fn handle_budget_target_editor(app: &mut App, key_event: KeyEvent) {
+    match (key_event.code, key_event.modifiers) {
+        (KeyCode::Esc, KeyModifiers::NONE) => app.cancel_budget_target_edit(),
+        (KeyCode::Enter, KeyModifiers::NONE) => app.save_budget_target(),
+        (KeyCode::Left, KeyModifiers::NONE) => app.move_cursor_left(),
+        (KeyCode::Right, KeyModifiers::NONE) => app.move_cursor_right(),
+        (KeyCode::Char(c), KeyModifiers::NONE) => app.insert_char_at_cursor(c),
+        (KeyCode::Backspace, KeyModifiers::NONE) => app.delete_char_before_cursor(),
+        (KeyCode::Delete, KeyModifiers::NONE) => app.delete_char_after_cursor(),
         _ => {}
     }
 }

--- a/src/events/runner.rs
+++ b/src/events/runner.rs
@@ -168,7 +168,9 @@ fn update(app: &mut App, key_event: KeyEvent) {
         AppMode::Summary | AppMode::CategorySummary => {
             summary_mode::handle_summary_mode(app, key_event)
         }
-        AppMode::Budget => budget_mode::handle_budget_mode(app, key_event),
+        AppMode::Budget | AppMode::BudgetCategoryEditor => {
+            budget_mode::handle_budget_mode(app, key_event)
+        }
         AppMode::SelectingCategory
         | AppMode::SelectingSubcategory
         | AppMode::SelectingFilterCategory

--- a/src/ui/budget.rs
+++ b/src/ui/budget.rs
@@ -3,7 +3,7 @@ use crate::ui::helpers::{format_amount, month_to_color, month_to_short_str};
 use ratatui::prelude::*;
 use ratatui::text::Line;
 use ratatui::widgets::{
-    Bar, BarChart, BarGroup, Block, Borders, Cell, Paragraph, Row, Table, Wrap,
+    Bar, BarChart, BarGroup, Block, Borders, Cell, Clear, Paragraph, Row, Table, Wrap,
 };
 use rust_decimal::Decimal;
 use rust_decimal::prelude::*;
@@ -239,6 +239,61 @@ fn compact_yearly_pattern_title(
                 .add_modifier(Modifier::BOLD),
         )]),
     }
+}
+
+pub fn render_budget_target_editor(f: &mut Frame, app: &App, area: Rect) {
+    // Fixed size: a percentage of a short terminal clips the input box.
+    let width = area.width.saturating_sub(4).clamp(24, 52).min(area.width);
+    let height = 7.min(area.height);
+    let popup_area = Rect {
+        x: area.x + area.width.saturating_sub(width) / 2,
+        y: area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    };
+    f.render_widget(Clear, popup_area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(1)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Min(0),
+        ])
+        .split(popup_area);
+
+    let block = Block::default()
+        .title(" Target Budget ")
+        .title_bottom(" [Enter] Save, [Esc] Cancel ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(PANEL_CHROME_COLOR));
+    f.render_widget(block, popup_area);
+
+    let label = app.budget_edit_label().unwrap_or_default();
+    let heading = Paragraph::new(Line::from(Span::styled(
+        label,
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    )))
+    .alignment(Alignment::Center);
+    f.render_widget(heading, chunks[0]);
+
+    let input = Paragraph::new(app.budget_edit_input.as_str()).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title("Amount (empty clears)")
+            .border_style(Style::default().fg(Color::Yellow)),
+    );
+    f.render_widget(input, chunks[1]);
+
+    let cursor_byte_idx = app.budget_edit_cursor.min(app.budget_edit_input.len());
+    let visual_cursor = app.budget_edit_input[..cursor_byte_idx].chars().count() as u16;
+    f.set_cursor_position(Position::new(
+        chunks[1].x + visual_cursor + 1,
+        chunks[1].y + 1,
+    ));
 }
 
 pub fn render_budget_view(f: &mut Frame, app: &mut App, area: Rect) {

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -212,10 +212,20 @@ pub fn render_help_bar(f: &mut Frame, app: &App, area: Rect) {
                     .add_modifier(Modifier::BOLD),
             ),
             Span::raw(" Year | "),
+            Span::styled("e", Style::default().fg(Color::LightYellow)),
+            Span::raw(" Edit Budget | "),
             Span::styled("c", Style::default().fg(Color::LightGreen)),
             Span::raw(" Edit Categories | "),
             Span::styled("q/Esc", Style::default().fg(Color::LightRed)),
             Span::raw(" Back"),
+        ],
+        AppMode::BudgetCategoryEditor => vec![
+            Span::raw("Type amount | "),
+            Span::raw("←→ Cursor | "),
+            Span::styled("Enter", Style::default().fg(Color::LightGreen)),
+            Span::raw(" Save | "),
+            Span::styled("Esc", Style::default().fg(Color::LightRed)),
+            Span::raw(" Cancel"),
         ],
         AppMode::Settings => vec![
             Span::styled(

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -120,6 +120,10 @@ pub(crate) fn ui(f: &mut Frame, app: &mut App) {
         AppMode::Budget => {
             budget::render_budget_view(f, app, main_area);
         }
+        AppMode::BudgetCategoryEditor => {
+            budget::render_budget_view(f, app, main_area);
+            budget::render_budget_target_editor(f, app, main_area);
+        }
         AppMode::CategoryCatalog | AppMode::CategoryCatalogFilter => {
             category_manager::render_category_catalog(f, app, main_area);
         }
@@ -178,7 +182,7 @@ pub(crate) fn ui(f: &mut Frame, app: &mut App) {
             .category_summary_years
             .get(app.category_summary_year_index)
             .copied(),
-        AppMode::Budget => app.selected_budget_year(),
+        AppMode::Budget | AppMode::BudgetCategoryEditor => app.selected_budget_year(),
         _ => None, // No year filter for other modes - show all transactions as before
     };
 


### PR DESCRIPTION
Allow budget categories to edit targets in place with a popup, including saving, cancellation, validation, and clearing budgets. Update documentation and keybinding help for the new workflow.