### PR TITLE
89 feature request enable viewing difference between total set budget limits of all catergories

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ cargo install budget-tracker-tui
 - Recurring transactions, from daily to yearly, generated automatically up to today or a forecast horizon you set
 - Hierarchical categories and subcategories, editable in-app, with optional fuzzy search
 - Monthly and category summaries with interactive charts
-- Monthly target budget plus optional per-category budgets, tracked in a dedicated budget view
+- Monthly target plus optional per-category budgets, tracked in a dedicated budget view
 - Multiple ledgers per database, for separate accounts or for forecasting apart from your real data
 - CSV import/export (duplicates skipped on import)
 - Local SQLite storage with decimal arithmetic (no floating-point rounding errors)
@@ -98,7 +98,7 @@ cargo install --path .
 
 ## Usage
 
-Launch with `budget-tracker`. The help bar at the bottom shows the keys for the current view, and `Ctrl+H` opens the full keybindings menu. Settings (`o`) is where you configure the database path, categories, CSV import/export, and target budget.
+Launch with `budget-tracker`. The help bar at the bottom shows the keys for the current view, and `Ctrl+H` opens the full keybindings menu. Settings (`o`) is where you configure the database path, categories, CSV import/export, and monthly target.
 
 For a more detailed walkthrough of every view and setting, see the [User Guide](docs/user-guide.md).
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -50,11 +50,19 @@ Forecast occurrences are derived in memory like every other generated occurrence
 
 ## Summary views
 
-**Monthly summary (`s`)** shows income, expenses, and net per month with an interactive chart. `↑`/`↓` move between months, `←`/`→` (or `[`/`]`) move between years. `m` toggles a multi-month line chart, and `c` toggles cumulative mode, which also draws the target budget line from settings.
+**Monthly summary (`s`)** shows income, expenses, and net per month with an interactive chart. `↑`/`↓` move between months, `←`/`→` (or `[`/`]`) move between years. `m` toggles a multi-month line chart, and `c` toggles cumulative mode, which also draws the monthly target line from settings.
 
 **Category summary (`c`)** breaks down each month by category. `Enter` expands or collapses a month, `PageUp`/`PageDown` move between months, `←`/`→` between years.
 
-**Budget view (`b`)** compares spending against your monthly target and any per-category budgets. `↑`/`↓` move between categories, `←`/`→` between months, `Shift+←`/`Shift+→` between years. Press `e` on a row to change that category's target budget in place. The popup starts on
+**Budget view (`b`)** compares spending against your monthly target and any per-category budgets. `↑`/`↓` move between categories, `←`/`→` between months, `Shift+←`/`Shift+→` between years.
+
+Under a *Category Budgets* heading, the status panel totals every category budget you have set
+(`Total`) and shows what is left over from the monthly target (`Spare`), so you can see how much of
+your budget is still unassigned without entering any transactions. `Spare` goes red and the status
+reads *Over Allocated* when your category budgets add up to more than the monthly target. Neither
+figure is tied to a month, which is why they hold steady as you move between months.
+
+Press `e` on a row to change that category's budget in place. The popup starts on
 the current amount; `Enter` saves, `Esc` cancels, and an empty amount clears the budget, which also
 drops the category from the table since only budgeted categories are listed. Press `c` to open the
 [category catalog](#the-category-catalog), which is where you set a budget on a category that
@@ -67,15 +75,15 @@ The catalog holds your categories and subcategories. Open it from Settings (*Man
 - `↑`/`↓` move between entries, `PageUp`/`PageDown` jump by page, `Ctrl+↑`/`Ctrl+↓` jump to the first/last entry
 - `f` filters the catalog as you type; `Enter` keeps the filter applied, `Esc` or `Ctrl+R` clears it
 - `a` adds a category, `e` or `Enter` edits the selected one, `d` deletes it
-- `1`-`5` (or `F1`-`F5`) sort by type, category, subcategory, tag, or target budget; pressing the same key again flips the direction, and the sorted column is marked in the header
-- Expense categories can optionally hold a per-category target budget, used by the budget view
+- `1`-`5` (or `F1`-`F5`) sort by type, category, subcategory, tag, or budget; pressing the same key again flips the direction, and the sorted column is marked in the header
+- Expense categories can optionally hold a budget, used by the budget view
 
 ## Ledgers
 
 A ledger is a self-contained set of transactions. One database can hold several of them, so you
 can keep separate books for different accounts or goals, or copy of a scenario to experiment with
 forecasting without touching your real data. Every ledger in a database **shares the same category
-catalog**, including per-category target budgets, so a category you rename or delete updates the
+catalog**, including per-category budgets, so a category you rename or delete updates the
 transactions in all of them.
 
 Open the list from Settings (*Ledger*, which shows the ledger currently open).
@@ -112,7 +120,7 @@ Press `o` to open settings. The menu is grouped into sections:
 
 **Monthly Summary View**
 
-- *Target Budget*: your monthly spending goal, drawn as a line in the monthly summary's cumulative mode and used by the budget view.
+- *Monthly Target*: your monthly spending goal, drawn as a line in the monthly summary's cumulative mode and used by the budget view.
 
 **Transaction View**
 

--- a/src/app/budget.rs
+++ b/src/app/budget.rs
@@ -273,7 +273,7 @@ impl App {
         comparisons.get(selected).cloned()
     }
 
-    // --- Target budget editing ---
+    // --- Category budget editing ---
 
     pub(crate) fn start_editing_budget_target(&mut self) {
         let Some(comparison) = self.selected_budget_category_comparison() else {

--- a/src/app/budget.rs
+++ b/src/app/budget.rs
@@ -216,6 +216,15 @@ impl App {
         self.budget_table_state.select(Some(previous));
     }
 
+    /// Same figure whichever month is selected, category budgets aren't month scoped.
+    pub(crate) fn total_allocated_budget(&self) -> Decimal {
+        self.category_records
+            .iter()
+            .filter(|record| record.transaction_type == TransactionType::Expense)
+            .filter_map(|record| record.target_budget)
+            .sum()
+    }
+
     pub(crate) fn budget_month_expense(&self, year: i32, month: u32) -> Decimal {
         self.monthly_summaries
             .get(&(year, month))

--- a/src/app/category_manager.rs
+++ b/src/app/category_manager.rs
@@ -484,7 +484,7 @@ impl App {
         };
 
         if transaction_type == TransactionType::Income && target_budget.is_some() {
-            return Err("Target budget is only available for expense categories.".to_string());
+            return Err("Budgets are only available for expense categories.".to_string());
         }
 
         Ok(CategoryDraft {

--- a/src/app/fields.rs
+++ b/src/app/fields.rs
@@ -198,7 +198,7 @@ form_fields! {
         Category => FieldKind::Text, "Category";
         Subcategory => FieldKind::Text, "Subcategory", "(Optional)";
         Tag => FieldKind::Text, "Tag", "(Optional)";
-        TargetBudget => FieldKind::Amount, "Target Budget", "(Optional, positive number)";
+        TargetBudget => FieldKind::Amount, "Budget", "(Optional, positive number)";
     }
 }
 

--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -337,10 +337,10 @@ pub fn get_help_for_mode(mode: AppMode) -> Vec<KeyBindingInfo> {
             KeyBindingInfo::new("Shift+←/→", "Change Year", "Navigation", None),
             KeyBindingInfo::new(
                 "e",
-                "Edit Target Budget",
+                "Edit Category Budget",
                 "Actions",
                 Some(
-                    "Change the target budget of the selected category right here. Leaving the amount empty removes the budget, which also drops the category from this table.",
+                    "Change the budget of the selected category right here. Leaving the amount empty removes the budget, which also drops the category from this table.",
                 ),
             ),
             KeyBindingInfo::new(
@@ -348,7 +348,7 @@ pub fn get_help_for_mode(mode: AppMode) -> Vec<KeyBindingInfo> {
                 "Manage Categories",
                 "Actions",
                 Some(
-                    "Open the category catalog to add or edit category target budgets without leaving the budget view. Esc returns here.",
+                    "Open the category catalog to add or edit category budgets without leaving the budget view. Esc returns here.",
                 ),
             ),
             KeyBindingInfo::new("q/Esc", "Back to Transactions", "Actions", None),
@@ -408,10 +408,12 @@ pub fn get_help_for_mode(mode: AppMode) -> Vec<KeyBindingInfo> {
                 ),
             ),
             KeyBindingInfo::new(
-                "Target Budget",
-                "Monthly Budget Goal",
+                "Monthly Target",
+                "Monthly spending goal",
                 "Fields",
-                Some("Set a target monthly budget amount for reference in summaries."),
+                Some(
+                    "Set the monthly spending goal used by the budget view and the summary's cumulative mode.",
+                ),
             ),
             KeyBindingInfo::new(
                 "Hourly Rate",
@@ -499,7 +501,7 @@ pub fn get_help_for_mode(mode: AppMode) -> Vec<KeyBindingInfo> {
             ),
             KeyBindingInfo::new(
                 "5/F5",
-                "Sort by Target Budget",
+                "Sort by Budget",
                 "Sorting",
                 Some(
                     "Groups the categories that have a budget set at the top; categories without one are listed last in both directions.",
@@ -534,11 +536,11 @@ pub fn get_help_for_mode(mode: AppMode) -> Vec<KeyBindingInfo> {
             KeyBindingInfo::new("Enter", "Toggle type or save", "Actions", None),
             KeyBindingInfo::new("Esc", "Cancel editor", "Actions", None),
             KeyBindingInfo::new(
-                "Target Budget",
+                "Budget",
                 "Expense-only category budget goal",
                 "Fields",
                 Some(
-                    "Optional for expense categories only. Income categories do not use per-category target budgets in the budget view.",
+                    "Optional for expense categories only. Income categories do not use per-category budgets in the budget view.",
                 ),
             ),
             KeyBindingInfo::new(

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -67,10 +67,10 @@ impl App {
             .unwrap_or_default();
         self.settings_state.add_setting(
             SettingKey::TargetBudget,
-            "Target Budget",
+            "Monthly Target",
             budget_val,
             SettingType::Number,
-            "Monthly spending goal. Displayed in Monthly Summary view only when cumulative mode.",
+            "Monthly spending goal. Used by the budget view, and drawn in the monthly summary's cumulative mode.",
         );
 
         // --- Transaction View Section ---
@@ -228,14 +228,14 @@ impl App {
             hide_help_bar_val = Some(val.to_lowercase().contains("yes"));
         }
 
-        // Validate Target Budget
+        // Validate Monthly Target
         let target_budget = if target_budget_str.is_empty() {
             None
         } else {
             match crate::validation::validate_amount_string(&target_budget_str) {
                 Ok(val) => Some(val),
                 Err(msg) => {
-                    self.set_status_message(format!("Error: Target budget - {}", msg), None);
+                    self.set_status_message(format!("Error: Monthly target - {}", msg), None);
                     return;
                 }
             }

--- a/src/ui/budget.rs
+++ b/src/ui/budget.rs
@@ -10,6 +10,7 @@ use rust_decimal::prelude::*;
 
 const PANEL_CHROME_COLOR: Color = Color::LightBlue;
 const SELECTED_MONTH_BAR_COLOR: Color = Color::Rgb(255, 165, 0);
+const WARNING_COLOR: Color = Color::Rgb(255, 165, 0); // orange
 
 fn budget_panel_block(title: Line<'static>, borders: Borders) -> Block<'static> {
     Block::default()
@@ -34,7 +35,7 @@ fn usage_color(actual: Decimal, target: Decimal) -> Color {
     if ratio > 1.0 {
         Color::LightRed
     } else if ratio >= 0.85 {
-        Color::Rgb(255, 165, 0) // orange
+        WARNING_COLOR
     } else if ratio >= 0.60 {
         Color::LightYellow
     } else {
@@ -264,7 +265,7 @@ pub fn render_budget_target_editor(f: &mut Frame, app: &App, area: Rect) {
         .split(popup_area);
 
     let block = Block::default()
-        .title(" Target Budget ")
+        .title(" Category Budget ")
         .title_bottom(" [Enter] Save, [Esc] Cancel ")
         .borders(Borders::ALL)
         .border_style(Style::default().fg(PANEL_CHROME_COLOR));
@@ -328,20 +329,21 @@ pub fn render_budget_view(f: &mut Frame, app: &mut App, area: Rect) {
         _ => Decimal::ZERO,
     };
     let remaining_budget = app.target_budget.map(|target| target - actual_expense);
-    let budget_status = match (app.target_budget, remaining_budget) {
-        (Some(_), Some(value)) if value < Decimal::ZERO => ("Over Budget", Color::LightRed),
-        (Some(_), _) => ("On Track", Color::LightGreen),
-        (None, _) => ("No Target Set", Color::LightYellow),
+    let allocated_budget = app.total_allocated_budget();
+    let unallocated_budget = app.target_budget.map(|target| target - allocated_budget);
+    // Overspending outranks over-allocating, so the worse news is the one on show.
+    let budget_status = match (app.target_budget, remaining_budget, unallocated_budget) {
+        (None, _, _) => ("No Target Set", Color::LightYellow),
+        (Some(_), Some(left), _) if left < Decimal::ZERO => ("Over Budget", Color::LightRed),
+        (Some(_), _, Some(spare)) if spare < Decimal::ZERO => ("Over Allocated", WARNING_COLOR),
+        _ => ("On Track", Color::LightGreen),
     };
     let usage_value = match app.target_budget {
         Some(target) => usage_percent(actual_expense, target),
         None => "N/A".to_string(),
     };
-    let allocated_budget = app.total_allocated_budget();
-    let unallocated_budget = app.target_budget.map(|target| target - allocated_budget);
-
     let mut allocated_spans = vec![
-        Span::styled("Alloc:  ", Style::default().add_modifier(Modifier::BOLD)),
+        Span::styled("Total:  ", Style::default().add_modifier(Modifier::BOLD)),
         Span::styled(
             format_amount(&allocated_budget),
             Style::default().fg(Color::LightBlue),
@@ -355,6 +357,15 @@ pub fn render_budget_view(f: &mut Frame, app: &mut App, area: Rect) {
         ));
     }
     let allocated_line = Line::from(allocated_spans);
+
+    let allocation_divider = Line::from(Span::styled(
+        format!(
+            "{:─<width$}",
+            "─ Category Budgets ",
+            width = top_chunks[0].width as usize
+        ),
+        Style::default().fg(Color::DarkGray),
+    ));
 
     let unallocated_line = Line::from(vec![
         Span::styled("Spare:  ", Style::default().add_modifier(Modifier::BOLD)),
@@ -443,6 +454,7 @@ pub fn render_budget_view(f: &mut Frame, app: &mut App, area: Rect) {
             Span::styled("Usage:  ", Style::default().add_modifier(Modifier::BOLD)),
             Span::styled(usage_value, Style::default().fg(Color::LightYellow)),
         ]),
+        allocation_divider,
         allocated_line,
         unallocated_line,
     ];

--- a/src/ui/budget.rs
+++ b/src/ui/budget.rs
@@ -337,6 +337,40 @@ pub fn render_budget_view(f: &mut Frame, app: &mut App, area: Rect) {
         Some(target) => usage_percent(actual_expense, target),
         None => "N/A".to_string(),
     };
+    let allocated_budget = app.total_allocated_budget();
+    let unallocated_budget = app.target_budget.map(|target| target - allocated_budget);
+
+    let mut allocated_spans = vec![
+        Span::styled("Alloc:  ", Style::default().add_modifier(Modifier::BOLD)),
+        Span::styled(
+            format_amount(&allocated_budget),
+            Style::default().fg(Color::LightBlue),
+        ),
+    ];
+    if let Some(target) = app.target_budget {
+        allocated_spans.push(Span::raw(" "));
+        allocated_spans.push(Span::styled(
+            format!("({})", usage_percent(allocated_budget, target)),
+            Style::default().fg(usage_color(allocated_budget, target)),
+        ));
+    }
+    let allocated_line = Line::from(allocated_spans);
+
+    let unallocated_line = Line::from(vec![
+        Span::styled("Spare:  ", Style::default().add_modifier(Modifier::BOLD)),
+        Span::styled(
+            match unallocated_budget {
+                Some(value) => format_budget_variance(value),
+                None => "N/A".to_string(),
+            },
+            match unallocated_budget {
+                Some(value) if value < Decimal::ZERO => Style::default().fg(Color::LightRed),
+                Some(_) => Style::default().fg(Color::LightGreen),
+                None => Style::default().fg(Color::White),
+            },
+        ),
+    ]);
+
     let status_lines = vec![
         Line::from(vec![
             Span::styled("Status: ", Style::default().add_modifier(Modifier::BOLD)),
@@ -409,6 +443,8 @@ pub fn render_budget_view(f: &mut Frame, app: &mut App, area: Rect) {
             Span::styled("Usage:  ", Style::default().add_modifier(Modifier::BOLD)),
             Span::styled(usage_value, Style::default().fg(Color::LightYellow)),
         ]),
+        allocated_line,
+        unallocated_line,
     ];
 
     let summary = Paragraph::new(status_lines)

--- a/src/ui/category_manager.rs
+++ b/src/ui/category_manager.rs
@@ -47,7 +47,7 @@ pub fn render_category_catalog(f: &mut Frame, app: &mut App, area: Rect) {
     } else {
         Style::default().fg(Color::Cyan).bold()
     };
-    let header_cells = ["Type", "Category", "Subcategory", "Tag", "Target Budget"]
+    let header_cells = ["Type", "Category", "Subcategory", "Tag", "Budget"]
         .iter()
         .zip(sort_columns.iter())
         .map(|(title, column)| {


### PR DESCRIPTION
Added the ability to understand more about different set budgets without having to have real data present yet. Helps with the budget building / planning parts and made the UI more clear. Made naming a bit more consistent also. 