### PR TITLE
[Feature] Add investment tracking and portfolio views

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ cargo install budget-tracker-tui
 - Hierarchical categories and subcategories, editable in-app, with optional fuzzy search
 - Monthly and category summaries with interactive charts
 - A monthly budget plus optional per-category budgets, tracked in a dedicated budget view and dated so changing one never rewrites past months
+- Manual investment tracking, recording valuations and contributions separately so growth is always derived rather than guessed
 - Multiple ledgers per database, for separate accounts or for forecasting apart from your real data
 - CSV import/export (duplicates skipped on import)
 - Local SQLite storage with decimal arithmetic (no floating-point rounding errors)
@@ -112,7 +113,7 @@ For a more detailed walkthrough of every view and setting, see the [User Guide](
 
 ## Data & configuration
 
-Transactions and categories live in a local SQLite database (`budget.db`), and app preferences in a `config.json`:
+Transactions, categories, and investments live in a local SQLite database (`budget.db`), and app preferences in a `config.json`:
 
 | OS      | Database                                       | Config                     |
 | ------- | ---------------------------------------------- | -------------------------- |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -12,6 +12,7 @@ The transaction list is where you land on launch, with a summary bar up top.
 - `f` opens the quick filter, `Ctrl+F` the advanced filter
 - `r` opens recurring settings for the selected transaction
 - `s`, `c`, and `b` open the monthly summary, category summary, and budget views
+- `i` opens the [investments view](#investments)
 - `o` opens settings
 - `q` or `Esc` clears any active filter, or quits the app when no filter is active
 
@@ -91,6 +92,97 @@ drops the category from the table since only budgeted categories are listed. Pre
 [category catalog](#the-category-catalog), which is where you set a budget on a category that
 doesn't have one yet.
 
+## Investments
+
+Press `i` from the main view to track what your investments are worth over time. Everything here is
+entered by hand: there are no live prices, and no connection to your bank. You record what you see
+when you check on an account, and the app works out the rest.
+
+The idea is that you never type in a gain. You record two different things:
+
+- a **valuation**, meaning "this account is worth $62,410 today"
+- a **contribution** or **withdrawal**, meaning money crossing the account boundary
+
+Growth is then whatever is left over: the change in value with your own money taken back out. Paying
+into an account can never make your returns look better than they were.
+
+### Getting started
+
+Press `a` to add an account. Give it a name and, optionally, a type: it's free text, so use whatever
+you actually call it (`Brokerage`, `Retirement (RRSP)`, `Crypto`).
+
+If the account already exists in real life, fill in the opening position too. **Starting Value** is
+what it's worth right now, and **Contributed So Far** is how much of that you put in yourself. They
+default to the same number, which is right if you're starting fresh. Set the contributed amount
+lower when part of the balance is growth you earned before you started tracking, otherwise the app
+will report your entire existing balance as a gain on day one. Zero is a valid answer too, for
+something you were given rather than bought.
+
+### Day to day
+
+`v` records a valuation, dated today, with the cursor already in the amount. It works from the
+accounts list or from inside an account, and it's the one to press whenever you check on your
+investments.
+
+`Enter` opens the selected account, showing its full entry history, its own growth chart, and a
+year-by-year breakdown of what you contributed against what it earned. `a`, `e` and `d` always act
+on whatever the rows on screen are: accounts on the list, entries inside an account. So `a` from
+inside an account adds an entry, and the *Entry* field (`←`/`→`) switches it between contribution,
+withdrawal and valuation.
+
+Recording a second valuation for an account on a date it already has one replaces it, since two
+different values for the same day don't mean anything.
+
+### Reading the numbers
+
+The chart draws your total value above your cumulative contributions. The vertical gap between the
+two lines is your gain at that moment, so growth is the gap widening. The y-axis always starts at
+zero, which is what keeps that gap readable as a proportion.
+
+`←`/`→` move the window through YTD, 1Y, 3Y, 5Y and All, but only the ranges that would actually
+show you less than All are offered. Two months into tracking an account, `1Y` and `5Y` would both
+just be All under a misleading label, so they're skipped until you have the history to fill them.
+The date labels follow suit, showing days on a short window, months on a medium one, and years on a
+long one.
+
+The panel above it puts the dollar figure first, because it's the one that isn't open to
+interpretation, then two rates that answer different questions:
+
+- **ROI** is simply your gain over what you put in. It's the number most people mean, but it's
+  distorted by *when* you contributed: money added last month has barely had a chance to grow
+- **Annual** is a time-weighted annualized return, which chains each year's performance and weights
+  contributions by how long they were actually invested. It's closer to "how well did these
+  investments do", independent of your deposit timing
+
+Both read `N/A` rather than guessing when there's nothing invested to measure against. Over periods
+shorter than a year, *Annual* reports the period return as-is instead of extrapolating a few weeks
+out to twelve months.
+
+Pick any range other than All and the third column also shows what you gained *within that window*,
+which is a different question from lifetime *Gain*: if you opened the account with a cost basis
+lower than its value, that earlier growth counts towards *Gain* but was never watched happening, so
+it belongs to no window. On All, that slot shows your oldest valuation date instead.
+
+Every window measures each account from its own first entry, so opening a new account today doesn't
+credit the portfolio with whatever it had already earned before you added it. Years run from the
+previous New Year's Eve rather than from January 1, in both the YTD figure and the per-year table in
+the account detail, so nothing recorded on New Year's Day falls between the two.
+
+### As-of dates and staleness
+
+Your portfolio total is a sum of valuations taken on different days, so the accounts table shows the
+date of each one. Anything older than 30 days is flagged with a `!` and the panel title counts how
+many are stale. It's a nudge to go and look, not an error.
+
+### Archiving
+
+Accounts you've closed can be archived with `A` (`Shift+A`) rather than deleted. Their history stays
+intact so past performance stays correct, but they drop out of the table and the totals. `A` toggles
+them back into view.
+
+Investments belong to the ledger they were created in, the same way transactions do, and are carried
+along when you copy a ledger.
+
 ## The category catalog
 
 The catalog holds your categories and subcategories. Open it from Settings (*Manage Categories*) or with `c` from the budget view. `q`/`Esc` returns to whichever view you came from.
@@ -165,7 +257,7 @@ Press `o` to open settings. The menu is grouped into sections:
 
 ## Data storage
 
-Transactions and categories are stored together in a local SQLite database (`budget.db`). On first run with a new database, it's seeded with the default category catalog and a ledger named `Main`. Default locations:
+Transactions, categories, and investments are stored together in a local SQLite database (`budget.db`). On first run with a new database, it's seeded with the default category catalog and a ledger named `Main`. Default locations:
 
 - **Linux:** `$XDG_DATA_HOME/BudgetTracker/budget.db` (usually `~/.local/share/BudgetTracker/budget.db`)
 - **macOS:** `~/Library/Application Support/BudgetTracker/budget.db`

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -176,9 +176,10 @@ many are stale. It's a nudge to go and look, not an error.
 
 ### Archiving
 
-Accounts you've closed can be archived with `A` (`Shift+A`) rather than deleted. Their history stays
-intact so past performance stays correct, but they drop out of the table and the totals. `A` toggles
-them back into view.
+Accounts you've closed can be archived rather than deleted. Press `e` on one and flip its *Status*
+field to `Archived`. Its history stays intact so past performance stays correct, but it drops out of
+the table and the totals. `A` (`Shift+A`) toggles archived accounts back into view so you can read
+them or unarchive one.
 
 Investments belong to the ledger they were created in, the same way transactions do, and are carried
 along when you copy a ledger.

--- a/src/app/fields.rs
+++ b/src/app/fields.rs
@@ -211,6 +211,31 @@ form_fields! {
     }
 }
 
+form_fields! {
+    /// The opening position fields only apply when creating an account. Editing one leaves
+    /// them inert, since by then its history is made of real entries you can edit directly.
+    pub enum InvestmentAccountField {
+        Name => FieldKind::Text, "Account Name";
+        Kind => FieldKind::Text, "Type", "(Optional - e.g. Brokerage, Retirement (RRSP), Crypto)";
+        Status => FieldKind::Toggle, "Status", "(◀/▶ to toggle)";
+        OpeningValue => FieldKind::Amount, "Starting Value", "(Optional - what it is worth now)";
+        OpeningInvested => FieldKind::Amount, "Contributed So Far",
+            "(Optional - defaults to the starting value)";
+        OpeningDate => FieldKind::Date, "As Of (YYYY-MM-DD)",
+            "(◀/▶ or +/- for days, Shift+◀/▶ for months)";
+    }
+}
+
+form_fields! {
+    pub enum InvestmentEntryField {
+        Date => FieldKind::Date, "Date (YYYY-MM-DD)",
+            "(◀/▶ or +/- for days, Shift+◀/▶ for months, Digits to enter)";
+        EntryKind => FieldKind::Toggle, "Entry", "(◀/▶ to toggle)";
+        Amount => FieldKind::Amount, "Amount";
+        Note => FieldKind::Text, "Note", "(Optional)";
+    }
+}
+
 /// Which form a category picker was opened from. The two forms have separate field sets, so a
 /// shared index could send the picked value back to the wrong one.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/app/help.rs
+++ b/src/app/help.rs
@@ -99,6 +99,14 @@ pub fn get_help_for_mode(mode: AppMode) -> Vec<KeyBindingInfo> {
                 ),
             ),
             KeyBindingInfo::new(
+                "i",
+                "Investments",
+                "Actions",
+                Some(
+                    "Track what your investments are worth over time. You record valuations and contributions separately, so growth is always derived rather than typed in.",
+                ),
+            ),
+            KeyBindingInfo::new(
                 "o",
                 "Settings",
                 "Actions",
@@ -571,6 +579,124 @@ pub fn get_help_for_mode(mode: AppMode) -> Vec<KeyBindingInfo> {
             KeyBindingInfo::new("y", "Confirm delete", "Actions", None),
             KeyBindingInfo::new("n/Esc", "Cancel delete", "Actions", None),
             KeyBindingInfo::new("Ctrl+H", "Show Keybindings Help", "System", None),
+        ],
+        AppMode::Investments => vec![
+            KeyBindingInfo::new("↑/↓", "Navigate accounts", "Navigation", None),
+            KeyBindingInfo::new(
+                "←/→",
+                "Change time range",
+                "Navigation",
+                Some(
+                    "Cycles the window every figure is measured over: YTD, 1Y, 3Y, 5Y, All. The chart, the period gain, and the annualized return all follow it.",
+                ),
+            ),
+            KeyBindingInfo::new(
+                "Enter",
+                "Open account detail",
+                "Actions",
+                Some(
+                    "Shows the account's full entry history, its own growth chart, and a year-by-year breakdown of what you contributed versus what it earned.",
+                ),
+            ),
+            KeyBindingInfo::new(
+                "v",
+                "Record a valuation",
+                "Actions",
+                Some(
+                    "Records what the account is worth today. This is the one to press whenever you check on your investments. Growth is worked out from the change since your last valuation, minus anything you paid in. To record money in or out instead, open the account with Enter and press 'a'.",
+                ),
+            ),
+            KeyBindingInfo::new(
+                "a",
+                "Add investment account",
+                "Actions",
+                Some(
+                    "Creates an account. If it already exists in real life, give it a starting value and how much of that you contributed, so growth is measured from the right place rather than counting your whole balance as a gain.",
+                ),
+            ),
+            KeyBindingInfo::new("e", "Edit selected account", "Actions", None),
+            KeyBindingInfo::new(
+                "d",
+                "Delete selected account",
+                "Actions",
+                Some("Permanently deletes the account and its entire history, after confirmation."),
+            ),
+            KeyBindingInfo::new(
+                "A",
+                "Show/hide archived accounts",
+                "Actions",
+                Some(
+                    "Archived accounts keep their history so past performance stays correct, but stay out of the table and the totals until you show them.",
+                ),
+            ),
+            KeyBindingInfo::new("q/Esc", "Back to transactions", "System", None),
+        ],
+        AppMode::InvestmentDetail => vec![
+            KeyBindingInfo::new("↑/↓", "Navigate entries", "Navigation", None),
+            KeyBindingInfo::new("←/→", "Change time range", "Navigation", None),
+            KeyBindingInfo::new(
+                "v",
+                "Record a valuation",
+                "Actions",
+                Some("Shortcut for adding an entry with the type already set to Valuation."),
+            ),
+            KeyBindingInfo::new(
+                "a",
+                "Add an entry",
+                "Actions",
+                Some(
+                    "Opens the entry form, set to Contribution. Use the Entry field to switch it to a withdrawal or a valuation.",
+                ),
+            ),
+            KeyBindingInfo::new("e/Enter", "Edit selected entry", "Actions", None),
+            KeyBindingInfo::new("d", "Delete selected entry", "Actions", None),
+            KeyBindingInfo::new("q/Esc", "Back to the accounts list", "System", None),
+        ],
+        AppMode::InvestmentAccountEditor => vec![
+            KeyBindingInfo::new("Tab/↑/↓", "Move between fields", "Navigation", None),
+            KeyBindingInfo::new("←/→", "Move cursor, or toggle status", "Navigation", None),
+            KeyBindingInfo::new(
+                "Starting Value",
+                "What the account is worth now",
+                "Fields",
+                Some(
+                    "Optional, and only offered when creating an account. Writes an opening valuation so an account you already held does not report its whole balance as a gain.",
+                ),
+            ),
+            KeyBindingInfo::new(
+                "Contributed So Far",
+                "Your cost basis",
+                "Fields",
+                Some(
+                    "Optional, defaults to the starting value. Set it lower when part of the balance is already growth you earned before you started tracking.",
+                ),
+            ),
+            KeyBindingInfo::new("Enter", "Save account", "Actions", None),
+            KeyBindingInfo::new("Esc", "Cancel", "System", None),
+        ],
+        AppMode::InvestmentEntryEditor => vec![
+            KeyBindingInfo::new("Tab/↑/↓", "Move between fields", "Navigation", None),
+            KeyBindingInfo::new(
+                "←/→",
+                "Move cursor, step the date, or toggle the entry",
+                "Navigation",
+                None,
+            ),
+            KeyBindingInfo::new("Shift+←/→", "Step the date by month", "Navigation", None),
+            KeyBindingInfo::new(
+                "Entry",
+                "Valuation, Contribution or Withdrawal",
+                "Fields",
+                Some(
+                    "A valuation records what the account is worth. A contribution or withdrawal records money crossing the boundary. Keeping them apart is what lets growth be derived rather than guessed.",
+                ),
+            ),
+            KeyBindingInfo::new("Enter", "Save entry", "Actions", None),
+            KeyBindingInfo::new("Esc", "Cancel", "System", None),
+        ],
+        AppMode::ConfirmInvestmentDelete => vec![
+            KeyBindingInfo::new("y", "Confirm deletion", "Actions", None),
+            KeyBindingInfo::new("n/Esc", "Cancel deletion", "Actions", None),
         ],
         AppMode::LedgerManager => vec![
             KeyBindingInfo::new("↑/↓", "Navigate ledgers", "Navigation", None),

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -41,6 +41,28 @@ impl App {
                     field.kind(),
                 ))
             }
+            AppMode::InvestmentAccountEditor => {
+                let field = self.investment_account_fields.focused();
+                if !field.kind().is_editable() {
+                    return None;
+                }
+                Some((
+                    &mut self.investment_account_fields[field],
+                    &mut self.investment_account_cursor,
+                    field.kind(),
+                ))
+            }
+            AppMode::InvestmentEntryEditor => {
+                let field = self.investment_entry_fields.focused();
+                if !field.kind().is_editable() {
+                    return None;
+                }
+                Some((
+                    &mut self.investment_entry_fields[field],
+                    &mut self.investment_entry_cursor,
+                    field.kind(),
+                ))
+            }
             AppMode::BudgetCategoryEditor => Some((
                 &mut self.budget_edit_input,
                 &mut self.budget_edit_cursor,
@@ -67,6 +89,15 @@ impl App {
                     field.kind(),
                 ))
             }
+            _ => None,
+        }
+    }
+
+    /// The focused input when it is a date field, so date stepping works in every form
+    /// without each one naming its own field.
+    pub(crate) fn active_date_input(&mut self) -> Option<(&mut String, &mut usize)> {
+        match self.get_active_input_mut() {
+            Some((content, cursor, FieldKind::Date)) => Some((content, cursor)),
             _ => None,
         }
     }

--- a/src/app/investments.rs
+++ b/src/app/investments.rs
@@ -166,7 +166,7 @@ impl App {
     }
 
     pub(crate) fn is_valuation_stale(&self, account_id: i64) -> bool {
-        match self.portfolio.last_valuation_date(account_id) {
+        match self.portfolio.last_valuation_date(account_id, self.today()) {
             Some(date) => (self.today() - date).num_days() > STALE_VALUATION_DAYS,
             None => false,
         }

--- a/src/app/investments.rs
+++ b/src/app/investments.rs
@@ -1,0 +1,702 @@
+use crate::app::fields::{InvestmentAccountField, InvestmentEntryField};
+use crate::app::state::{App, AppMode, InvestmentDeleteTarget};
+use crate::db::investment_store::InvestmentStore;
+use crate::model::{
+    DATE_FORMAT, InvestmentAccountDraft, InvestmentEntryDraft, InvestmentEntryKind,
+    InvestmentPosition, InvestmentRange,
+};
+use chrono::{Duration, NaiveDate};
+use rust_decimal::Decimal;
+
+pub const STALE_VALUATION_DAYS: i64 = 30;
+
+const STATUS_ACTIVE: &str = "Active";
+const STATUS_ARCHIVED: &str = "Archived";
+
+impl App {
+    pub(crate) fn today(&self) -> NaiveDate {
+        chrono::Local::now().date_naive()
+    }
+
+    pub(crate) fn enter_investments_mode(&mut self) {
+        if let Err(err) = self.reload_portfolio() {
+            self.set_status_message(format!("Error loading investments: {}", err), None);
+            return;
+        }
+
+        self.mode = AppMode::Investments;
+        self.investment_detail_id = None;
+        self.clamp_investment_selection();
+        self.clamp_investment_range();
+        self.clear_status_message();
+    }
+
+    pub(crate) fn exit_investments_mode(&mut self) {
+        self.mode = AppMode::Normal;
+        self.investment_detail_id = None;
+        self.clear_status_message();
+    }
+
+    // --- Overview navigation ---
+
+    pub(crate) fn visible_investment_ids(&self) -> Vec<i64> {
+        self.portfolio
+            .visible_accounts(self.show_archived_investments)
+            .iter()
+            .map(|account| account.id)
+            .collect()
+    }
+
+    pub(crate) fn selected_investment_account_id(&self) -> Option<i64> {
+        let ids = self.visible_investment_ids();
+        self.investment_table_state
+            .selected()
+            .and_then(|index| ids.get(index).copied())
+    }
+
+    pub(crate) fn active_investment_account_id(&self) -> Option<i64> {
+        self.investment_detail_id
+            .or_else(|| self.selected_investment_account_id())
+    }
+
+    fn clamp_investment_selection(&mut self) {
+        let len = self.visible_investment_ids().len();
+        if len == 0 {
+            self.investment_table_state.select(None);
+            return;
+        }
+        let index = self
+            .investment_table_state
+            .selected()
+            .unwrap_or(0)
+            .min(len - 1);
+        self.investment_table_state.select(Some(index));
+    }
+
+    pub(crate) fn next_investment_account(&mut self) {
+        let len = self.visible_investment_ids().len();
+        if len == 0 {
+            return;
+        }
+        let index = match self.investment_table_state.selected() {
+            Some(current) if current + 1 < len => current + 1,
+            _ => 0,
+        };
+        self.investment_table_state.select(Some(index));
+    }
+
+    pub(crate) fn previous_investment_account(&mut self) {
+        let len = self.visible_investment_ids().len();
+        if len == 0 {
+            return;
+        }
+        let index = match self.investment_table_state.selected() {
+            Some(0) | None => len - 1,
+            Some(current) => current - 1,
+        };
+        self.investment_table_state.select(Some(index));
+    }
+
+    pub(crate) fn available_investment_ranges(&self) -> Vec<InvestmentRange> {
+        let today = self.today();
+        let earliest = self
+            .portfolio
+            .earliest_date(self.investment_detail_id, self.show_archived_investments);
+        let mut ranges: Vec<InvestmentRange> = InvestmentRange::all()
+            .into_iter()
+            .filter(|range| range.crops(today, earliest))
+            .collect();
+        ranges.push(InvestmentRange::All);
+        ranges
+    }
+
+    pub(crate) fn cycle_investment_range(&mut self, forward: bool) {
+        let ranges = self.available_investment_ranges();
+        let index = ranges
+            .iter()
+            .position(|range| *range == self.investment_range)
+            .unwrap_or(ranges.len() - 1);
+        let next = if forward {
+            (index + 1) % ranges.len()
+        } else {
+            (index + ranges.len() - 1) % ranges.len()
+        };
+        self.investment_range = ranges[next];
+    }
+
+    fn clamp_investment_range(&mut self) {
+        if !self
+            .available_investment_ranges()
+            .contains(&self.investment_range)
+        {
+            self.investment_range = InvestmentRange::All;
+        }
+    }
+
+    pub(crate) fn toggle_archived_investments(&mut self) {
+        self.show_archived_investments = !self.show_archived_investments;
+        self.clamp_investment_selection();
+        let message = if self.show_archived_investments {
+            "Showing archived accounts."
+        } else {
+            "Hiding archived accounts."
+        };
+        self.set_status_message(message, Some(Duration::seconds(2)));
+    }
+
+    pub(crate) fn investment_window(&self) -> (NaiveDate, NaiveDate) {
+        let today = self.today();
+        let start = self.investment_range.start(
+            today,
+            self.portfolio
+                .earliest_date(self.investment_detail_id, self.show_archived_investments),
+        );
+        (start, today)
+    }
+
+    pub(crate) fn investment_position(&self) -> InvestmentPosition {
+        let today = self.today();
+        match self.investment_detail_id {
+            Some(id) => self.portfolio.position(id, today),
+            None => self
+                .portfolio
+                .total_position(today, self.show_archived_investments),
+        }
+    }
+
+    pub(crate) fn is_valuation_stale(&self, account_id: i64) -> bool {
+        match self.portfolio.last_valuation_date(account_id) {
+            Some(date) => (self.today() - date).num_days() > STALE_VALUATION_DAYS,
+            None => false,
+        }
+    }
+
+    // --- Detail view ---
+
+    pub(crate) fn open_investment_detail(&mut self) {
+        let Some(id) = self.selected_investment_account_id() else {
+            return;
+        };
+        self.investment_detail_id = Some(id);
+        self.mode = AppMode::InvestmentDetail;
+        let has_entries = !self.detail_entry_ids().is_empty();
+        self.investment_entry_table_state
+            .select(has_entries.then_some(0));
+        self.clear_status_message();
+    }
+
+    pub(crate) fn exit_investment_detail(&mut self) {
+        self.investment_detail_id = None;
+        self.mode = AppMode::Investments;
+        self.clear_status_message();
+    }
+
+    /// Newest first, matching the table.
+    pub(crate) fn detail_entry_ids(&self) -> Vec<i64> {
+        let Some(account_id) = self.investment_detail_id else {
+            return Vec::new();
+        };
+        let mut ids: Vec<i64> = self
+            .portfolio
+            .entries_for(account_id)
+            .map(|entry| entry.id)
+            .collect();
+        ids.reverse();
+        ids
+    }
+
+    pub(crate) fn selected_investment_entry_id(&self) -> Option<i64> {
+        let ids = self.detail_entry_ids();
+        self.investment_entry_table_state
+            .selected()
+            .and_then(|index| ids.get(index).copied())
+    }
+
+    pub(crate) fn next_investment_entry(&mut self) {
+        let len = self.detail_entry_ids().len();
+        if len == 0 {
+            return;
+        }
+        let index = match self.investment_entry_table_state.selected() {
+            Some(current) if current + 1 < len => current + 1,
+            _ => 0,
+        };
+        self.investment_entry_table_state.select(Some(index));
+    }
+
+    pub(crate) fn previous_investment_entry(&mut self) {
+        let len = self.detail_entry_ids().len();
+        if len == 0 {
+            return;
+        }
+        let index = match self.investment_entry_table_state.selected() {
+            Some(0) | None => len - 1,
+            Some(current) => current - 1,
+        };
+        self.investment_entry_table_state.select(Some(index));
+    }
+
+    // --- Account editor ---
+
+    pub(crate) fn start_adding_investment_account(&mut self) {
+        self.investment_account_fields.reset();
+        self.investment_account_fields[InvestmentAccountField::Status] = STATUS_ACTIVE.to_string();
+        self.investment_account_fields[InvestmentAccountField::OpeningDate] =
+            self.today().format(DATE_FORMAT).to_string();
+        self.editing_investment_account_id = None;
+        self.investment_account_cursor = 0;
+        self.mode = AppMode::InvestmentAccountEditor;
+        self.clear_status_message();
+    }
+
+    pub(crate) fn start_editing_investment_account(&mut self) {
+        let Some(account) = self
+            .active_investment_account_id()
+            .and_then(|id| self.portfolio.account(id))
+        else {
+            return;
+        };
+
+        let (id, name, kind, archived) = (
+            account.id,
+            account.name.clone(),
+            account.kind.clone(),
+            account.archived,
+        );
+
+        self.investment_account_fields.reset();
+        self.investment_account_fields[InvestmentAccountField::Name] = name;
+        self.investment_account_fields[InvestmentAccountField::Kind] = kind;
+        self.investment_account_fields[InvestmentAccountField::Status] = if archived {
+            STATUS_ARCHIVED.to_string()
+        } else {
+            STATUS_ACTIVE.to_string()
+        };
+        self.editing_investment_account_id = Some(id);
+        self.investment_account_cursor = self.investment_account_fields.focused_value().len();
+        self.mode = AppMode::InvestmentAccountEditor;
+        self.clear_status_message();
+    }
+
+    pub(crate) fn cancel_investment_account_editor(&mut self) {
+        self.editing_investment_account_id = None;
+        self.investment_account_fields.reset();
+        self.investment_account_cursor = 0;
+        self.mode = self.investment_return_mode();
+        self.clear_status_message();
+    }
+
+    pub(crate) fn investment_opening_fields_active(&self) -> bool {
+        self.editing_investment_account_id.is_none()
+    }
+
+    pub(crate) fn next_investment_account_field(&mut self) {
+        self.investment_account_fields.focus_next();
+        self.investment_account_cursor = self.investment_account_fields.focused_value().len();
+    }
+
+    pub(crate) fn previous_investment_account_field(&mut self) {
+        self.investment_account_fields.focus_previous();
+        self.investment_account_cursor = self.investment_account_fields.focused_value().len();
+    }
+
+    pub(crate) fn toggle_investment_status(&mut self) {
+        let field = &mut self.investment_account_fields[InvestmentAccountField::Status];
+        *field = if field == STATUS_ARCHIVED {
+            STATUS_ACTIVE.to_string()
+        } else {
+            STATUS_ARCHIVED.to_string()
+        };
+    }
+
+    pub(crate) fn save_investment_account(&mut self) {
+        let name = self.investment_account_fields[InvestmentAccountField::Name]
+            .trim()
+            .to_string();
+        if name.is_empty() {
+            self.set_status_message("Error: Account name cannot be empty", None);
+            return;
+        }
+
+        let draft = InvestmentAccountDraft {
+            name: name.clone(),
+            kind: self.investment_account_fields[InvestmentAccountField::Kind]
+                .trim()
+                .to_string(),
+            archived: self.investment_account_fields[InvestmentAccountField::Status]
+                == STATUS_ARCHIVED,
+        };
+
+        let opening = match self.parse_opening_position() {
+            Ok(opening) => opening,
+            Err(message) => {
+                self.set_status_message(format!("Error: {}", message), None);
+                return;
+            }
+        };
+
+        let store = self.investment_store();
+        let saved_id = match self.editing_investment_account_id {
+            Some(id) => store.update_account(id, &draft).map(|_| id),
+            None => store.create_account(&draft),
+        };
+
+        let account_id = match saved_id {
+            Ok(id) => id,
+            Err(err) => {
+                self.set_status_message(format!("Error saving account: {}", err), None);
+                return;
+            }
+        };
+
+        let opening_error = opening.and_then(|(date, value, invested)| {
+            let mut entries = Vec::new();
+            // Nothing contributed is a real position: a gift, a match, something inherited.
+            if invested > Decimal::ZERO {
+                entries.push((InvestmentEntryKind::Contribution, invested));
+            }
+            entries.push((InvestmentEntryKind::Valuation, value));
+
+            entries
+                .into_iter()
+                .try_for_each(|(entry_kind, amount)| {
+                    store
+                        .save_entry(&InvestmentEntryDraft {
+                            account_id,
+                            date,
+                            entry_kind,
+                            amount,
+                            note: "Opening position".to_string(),
+                        })
+                        .map(|_| ())
+                })
+                .err()
+        });
+
+        let was_edit = self.editing_investment_account_id.is_some();
+        self.editing_investment_account_id = None;
+        self.investment_account_fields.reset();
+        self.investment_account_cursor = 0;
+        self.mode = self.investment_return_mode();
+
+        let message = match (&opening_error, was_edit) {
+            (Some(err), _) => format!("Account saved, but the opening position failed: {}", err),
+            (None, true) => format!("Account '{}' updated.", name),
+            (None, false) => format!("Account '{}' added.", name),
+        };
+        self.finish_investment_write(Some(account_id), message);
+        if opening_error.is_some() {
+            // A failed opening position needs to stay on screen.
+            self.status_expiry = None;
+        }
+    }
+
+    fn parse_opening_position(&self) -> Result<Option<(NaiveDate, Decimal, Decimal)>, String> {
+        if !self.investment_opening_fields_active() {
+            return Ok(None);
+        }
+
+        let value_str = self.investment_account_fields[InvestmentAccountField::OpeningValue].trim();
+        let invested_str =
+            self.investment_account_fields[InvestmentAccountField::OpeningInvested].trim();
+        if value_str.is_empty() {
+            if !invested_str.is_empty() {
+                return Err("Set a starting value to go with the contributed amount".to_string());
+            }
+            return Ok(None);
+        }
+
+        let value = crate::validation::validate_non_negative_amount_string(value_str)?;
+        let invested = if invested_str.is_empty() {
+            value
+        } else {
+            crate::validation::validate_non_negative_amount_string(invested_str)?
+        };
+
+        let date_str = self.investment_account_fields[InvestmentAccountField::OpeningDate].trim();
+        let date = NaiveDate::parse_from_str(date_str, DATE_FORMAT)
+            .map_err(|_| format!("Invalid As Of date (expected {})", DATE_FORMAT))?;
+
+        Ok(Some((date, value, invested)))
+    }
+
+    // --- Entry editor ---
+
+    pub(crate) fn start_recording_valuation(&mut self) {
+        self.open_entry_editor(InvestmentEntryKind::Valuation);
+    }
+
+    pub(crate) fn start_adding_investment_entry(&mut self) {
+        self.open_entry_editor(InvestmentEntryKind::Contribution);
+    }
+
+    fn open_entry_editor(&mut self, kind: InvestmentEntryKind) {
+        if self.active_investment_account_id().is_none() {
+            self.set_status_message("Add an investment account first (press a).", None);
+            return;
+        }
+
+        self.investment_entry_fields.reset();
+        self.investment_entry_fields[InvestmentEntryField::Date] =
+            self.today().format(DATE_FORMAT).to_string();
+        self.investment_entry_fields[InvestmentEntryField::EntryKind] = kind.as_str().to_string();
+        self.investment_entry_fields
+            .focus(InvestmentEntryField::Amount);
+        self.editing_investment_entry_id = None;
+        self.investment_entry_cursor = 0;
+        self.mode = AppMode::InvestmentEntryEditor;
+        self.clear_status_message();
+    }
+
+    pub(crate) fn start_editing_investment_entry(&mut self) {
+        let Some(entry) = self.selected_investment_entry_id().and_then(|id| {
+            self.investment_detail_id
+                .and_then(|account| self.portfolio.entries_for(account).find(|e| e.id == id))
+        }) else {
+            return;
+        };
+
+        let (id, date, kind, amount, note) = (
+            entry.id,
+            entry.date,
+            entry.entry_kind,
+            entry.amount,
+            entry.note.clone(),
+        );
+
+        self.investment_entry_fields.reset();
+        self.investment_entry_fields[InvestmentEntryField::Date] =
+            date.format(DATE_FORMAT).to_string();
+        self.investment_entry_fields[InvestmentEntryField::EntryKind] = kind.as_str().to_string();
+        self.investment_entry_fields[InvestmentEntryField::Amount] = amount.normalize().to_string();
+        self.investment_entry_fields[InvestmentEntryField::Note] = note;
+        self.investment_entry_fields
+            .focus(InvestmentEntryField::Amount);
+        self.editing_investment_entry_id = Some(id);
+        self.investment_entry_cursor = self.investment_entry_fields.focused_value().len();
+        self.mode = AppMode::InvestmentEntryEditor;
+        self.clear_status_message();
+    }
+
+    pub(crate) fn cancel_investment_entry_editor(&mut self) {
+        self.editing_investment_entry_id = None;
+        self.investment_entry_fields.reset();
+        self.investment_entry_cursor = 0;
+        self.mode = self.investment_return_mode();
+        self.clear_status_message();
+    }
+
+    pub(crate) fn next_investment_entry_field(&mut self) {
+        self.investment_entry_fields.focus_next();
+        self.investment_entry_cursor = self.investment_entry_fields.focused_value().len();
+    }
+
+    pub(crate) fn previous_investment_entry_field(&mut self) {
+        self.investment_entry_fields.focus_previous();
+        self.investment_entry_cursor = self.investment_entry_fields.focused_value().len();
+    }
+
+    pub(crate) fn cycle_investment_entry_kind(&mut self, forward: bool) {
+        let all = InvestmentEntryKind::all();
+        let current = InvestmentEntryKind::from_label(
+            &self.investment_entry_fields[InvestmentEntryField::EntryKind],
+        )
+        .unwrap_or(InvestmentEntryKind::Valuation);
+        let index = all.iter().position(|kind| *kind == current).unwrap_or(0);
+        let next = if forward {
+            (index + 1) % all.len()
+        } else {
+            (index + all.len() - 1) % all.len()
+        };
+        self.investment_entry_fields[InvestmentEntryField::EntryKind] =
+            all[next].as_str().to_string();
+    }
+
+    pub(crate) fn save_investment_entry(&mut self) {
+        let Some(account_id) = self.active_investment_account_id() else {
+            self.set_status_message("Error: No investment account selected", None);
+            return;
+        };
+
+        let kind = InvestmentEntryKind::from_label(
+            &self.investment_entry_fields[InvestmentEntryField::EntryKind],
+        )
+        .unwrap_or(InvestmentEntryKind::Valuation);
+
+        let date_str = self.investment_entry_fields[InvestmentEntryField::Date].trim();
+        let date = match NaiveDate::parse_from_str(date_str, DATE_FORMAT) {
+            Ok(date) => date,
+            Err(_) => {
+                self.set_status_message(
+                    format!("Error: Invalid Date Format (Expected {})", DATE_FORMAT),
+                    None,
+                );
+                return;
+            }
+        };
+
+        let amount_str = self.investment_entry_fields[InvestmentEntryField::Amount].trim();
+        let parsed = match kind {
+            InvestmentEntryKind::Valuation => {
+                crate::validation::validate_non_negative_amount_string(amount_str)
+            }
+            _ => crate::validation::validate_amount_string(amount_str),
+        };
+        let amount = match parsed {
+            Ok(amount) => amount,
+            Err(message) => {
+                self.set_status_message(format!("Error: {}", message), None);
+                return;
+            }
+        };
+
+        let draft = InvestmentEntryDraft {
+            account_id,
+            date,
+            entry_kind: kind,
+            amount,
+            note: self.investment_entry_fields[InvestmentEntryField::Note]
+                .trim()
+                .to_string(),
+        };
+
+        let store = self.investment_store();
+        let result = match self.editing_investment_entry_id {
+            Some(id) => store.update_entry(id, &draft).map(|_| id),
+            None => store.save_entry(&draft),
+        };
+
+        if let Err(err) = result {
+            self.set_status_message(format!("Error saving entry: {}", err), None);
+            return;
+        }
+
+        let was_edit = self.editing_investment_entry_id.is_some();
+        self.editing_investment_entry_id = None;
+        self.investment_entry_fields.reset();
+        self.investment_entry_cursor = 0;
+        self.mode = self.investment_return_mode();
+        self.finish_investment_write(
+            None,
+            if was_edit {
+                format!("{} updated.", kind.as_str())
+            } else {
+                format!("{} recorded.", kind.as_str())
+            },
+        );
+    }
+
+    // --- Deleting ---
+
+    pub(crate) fn prepare_delete_investment(&mut self) {
+        let target = match self.mode {
+            AppMode::InvestmentDetail => self
+                .selected_investment_entry_id()
+                .map(InvestmentDeleteTarget::Entry),
+            _ => self
+                .selected_investment_account_id()
+                .map(InvestmentDeleteTarget::Account),
+        };
+
+        let Some(target) = target else {
+            return;
+        };
+
+        self.investment_delete_prompt = match target {
+            InvestmentDeleteTarget::Account(id) => {
+                let name = self
+                    .portfolio
+                    .account(id)
+                    .map(|account| account.name.clone())
+                    .unwrap_or_default();
+                let count = self.portfolio.entries_for(id).count();
+                format!(
+                    "Delete '{}' and its {} entr{}? (y/n)",
+                    name,
+                    count,
+                    if count == 1 { "y" } else { "ies" }
+                )
+            }
+            InvestmentDeleteTarget::Entry(_) => "Delete selected entry? (y/n)".to_string(),
+        };
+        self.investment_delete_target = Some(target);
+        self.mode = AppMode::ConfirmInvestmentDelete;
+    }
+
+    pub(crate) fn cancel_delete_investment(&mut self) {
+        self.investment_delete_target = None;
+        self.mode = self.investment_return_mode();
+        self.clear_status_message();
+    }
+
+    pub(crate) fn confirm_delete_investment(&mut self) {
+        let Some(target) = self.investment_delete_target else {
+            self.cancel_delete_investment();
+            return;
+        };
+
+        let store = self.investment_store();
+        let (result, message) = match target {
+            InvestmentDeleteTarget::Account(id) => {
+                (store.delete_account(id), "Account deleted.".to_string())
+            }
+            InvestmentDeleteTarget::Entry(id) => {
+                (store.delete_entry(id), "Entry deleted.".to_string())
+            }
+        };
+
+        // Leave the dialog first, so no error path strands it on a deleted id.
+        self.investment_delete_target = None;
+        if let InvestmentDeleteTarget::Account(id) = target
+            && self.investment_detail_id == Some(id)
+        {
+            self.investment_detail_id = None;
+        }
+        self.mode = self.investment_return_mode();
+
+        if let Err(err) = result {
+            self.set_status_message(format!("Error deleting: {}", err), None);
+            return;
+        }
+        self.finish_investment_write(None, message);
+    }
+
+    // --- Shared plumbing ---
+
+    fn investment_return_mode(&self) -> AppMode {
+        if self.investment_detail_id.is_some() {
+            AppMode::InvestmentDetail
+        } else {
+            AppMode::Investments
+        }
+    }
+
+    fn finish_investment_write(&mut self, select: Option<i64>, message: String) {
+        if let Err(err) = self.reload_portfolio() {
+            self.set_status_message(format!("Saved, but reloading failed: {}", err), None);
+            return;
+        }
+
+        if let Some(id) = select
+            && let Some(index) = self.visible_investment_ids().iter().position(|v| *v == id)
+        {
+            self.investment_table_state.select(Some(index));
+        }
+        self.clamp_investment_selection();
+        self.clamp_investment_range();
+
+        let entries = self.detail_entry_ids().len();
+        if entries == 0 {
+            self.investment_entry_table_state.select(None);
+        } else {
+            let index = self
+                .investment_entry_table_state
+                .selected()
+                .unwrap_or(0)
+                .min(entries - 1);
+            self.investment_entry_table_state.select(Some(index));
+        }
+
+        self.set_status_message(message, Some(Duration::seconds(3)));
+    }
+}

--- a/src/app/investments.rs
+++ b/src/app/investments.rs
@@ -136,6 +136,7 @@ impl App {
     pub(crate) fn toggle_archived_investments(&mut self) {
         self.show_archived_investments = !self.show_archived_investments;
         self.clamp_investment_selection();
+        self.clamp_investment_range();
         let message = if self.show_archived_investments {
             "Showing archived accounts."
         } else {
@@ -179,6 +180,7 @@ impl App {
         };
         self.investment_detail_id = Some(id);
         self.mode = AppMode::InvestmentDetail;
+        self.clamp_investment_range();
         let has_entries = !self.detail_entry_ids().is_empty();
         self.investment_entry_table_state
             .select(has_entries.then_some(0));
@@ -188,6 +190,7 @@ impl App {
     pub(crate) fn exit_investment_detail(&mut self) {
         self.investment_detail_id = None;
         self.mode = AppMode::Investments;
+        self.clamp_investment_range();
         self.clear_status_message();
     }
 

--- a/src/app/ledger_manager.rs
+++ b/src/app/ledger_manager.rs
@@ -225,14 +225,28 @@ impl App {
             .find(|ledger| ledger.id == id)
             .map(|ledger| ledger.name.clone())
             .unwrap_or_default();
-        let count = self.ledger_store().transaction_count(id).unwrap_or(0);
+        let store = self.ledger_store();
+        let count = store.transaction_count(id).unwrap_or(0);
+        let accounts = store.investment_account_count(id).unwrap_or(0);
 
-        self.ledger_delete_prompt = format!(
-            "Delete '{}' and its {} transaction{}? (y/n)",
-            name,
-            count,
-            if count == 1 { "" } else { "s" }
-        );
+        let plural = |n: i64| if n == 1 { "" } else { "s" };
+        self.ledger_delete_prompt = if accounts > 0 {
+            format!(
+                "Delete '{}' with its {} transaction{} and {} investment account{}? (y/n)",
+                name,
+                count,
+                plural(count),
+                accounts,
+                plural(accounts)
+            )
+        } else {
+            format!(
+                "Delete '{}' and its {} transaction{}? (y/n)",
+                name,
+                count,
+                plural(count)
+            )
+        };
         self.ledger_delete_id = Some(id);
         self.mode = AppMode::ConfirmLedgerDelete;
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -7,6 +7,7 @@ pub mod filter;
 pub mod fuzzy_search;
 pub mod help;
 pub mod input;
+pub mod investments;
 pub mod ledger_manager;
 pub mod recurring;
 pub mod settings;

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -1,5 +1,6 @@
 use crate::app::fields::{
-    AddEditField, AdvancedFilterField, CategoryEditField, FieldSet, RecurringField, SelectingField,
+    AddEditField, AdvancedFilterField, CategoryEditField, FieldSet, InvestmentAccountField,
+    InvestmentEntryField, RecurringField, SelectingField,
 };
 use crate::app::update_checker;
 use crate::config::{AppSettings, load_settings, save_settings};
@@ -7,6 +8,7 @@ use crate::csv_io::{load_seed_categories, load_transactions};
 use crate::db::budget_store::{BudgetStore, SqliteBudgetStore};
 use crate::db::category_store::{CategoryStore, SqliteCategoryStore};
 use crate::db::database::{SCHEMA_VERSION, SqliteDatabase};
+use crate::db::investment_store::{InvestmentStore, SqliteInvestmentStore};
 use crate::db::ledger_store::{DEFAULT_LEDGER_ID, LedgerRecord, LedgerStore, SqliteLedgerStore};
 use crate::db::transaction_store::{SqliteTransactionStore, TransactionStore};
 use crate::model::*;
@@ -56,6 +58,17 @@ pub enum AppMode {
     LedgerManager,
     LedgerEditor,
     ConfirmLedgerDelete,
+    Investments,
+    InvestmentDetail,
+    InvestmentAccountEditor,
+    InvestmentEntryEditor,
+    ConfirmInvestmentDelete,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvestmentDeleteTarget {
+    Account(i64),
+    Entry(i64),
 }
 
 #[derive(Debug)]
@@ -169,6 +182,21 @@ pub struct App {
     pub(crate) ledger_delete_id: Option<i64>,
     pub(crate) ledger_delete_prompt: String,
     pub(crate) ledger_copy_source_id: Option<i64>,
+    // Investments
+    pub(crate) portfolio: Portfolio,
+    pub(crate) investment_table_state: TableState,
+    pub(crate) investment_entry_table_state: TableState,
+    pub(crate) investment_range: InvestmentRange,
+    pub(crate) show_archived_investments: bool,
+    pub(crate) investment_detail_id: Option<i64>,
+    pub(crate) investment_account_fields: FieldSet<InvestmentAccountField, 6>,
+    pub(crate) investment_account_cursor: usize,
+    pub(crate) editing_investment_account_id: Option<i64>,
+    pub(crate) investment_entry_fields: FieldSet<InvestmentEntryField, 4>,
+    pub(crate) investment_entry_cursor: usize,
+    pub(crate) editing_investment_entry_id: Option<i64>,
+    pub(crate) investment_delete_target: Option<InvestmentDeleteTarget>,
+    pub(crate) investment_delete_prompt: String,
     // Budget
     pub(crate) hourly_rate: Option<Decimal>,
     pub(crate) show_hours: bool,
@@ -393,6 +421,20 @@ impl App {
             ledger_delete_id: None,
             ledger_delete_prompt: String::new(),
             ledger_copy_source_id: None,
+            portfolio: Portfolio::default(),
+            investment_table_state: TableState::default(),
+            investment_entry_table_state: TableState::default(),
+            investment_range: InvestmentRange::All,
+            show_archived_investments: false,
+            investment_detail_id: None,
+            investment_account_fields: Default::default(),
+            investment_account_cursor: 0,
+            editing_investment_account_id: None,
+            investment_entry_fields: Default::default(),
+            investment_entry_cursor: 0,
+            editing_investment_entry_id: None,
+            investment_delete_target: None,
+            investment_delete_prompt: String::new(),
             hourly_rate: loaded_settings.hourly_rate,
             show_hours: loaded_settings.show_hours.unwrap_or(false),
             fuzzy_search_mode: loaded_settings.fuzzy_search_mode.unwrap_or(false),
@@ -429,6 +471,9 @@ impl App {
             .and_then(|_| app.migrate_legacy_target_budget())
         {
             app.status_message = Some(format!("Budget load error: {}", err));
+        }
+        if let Err(err) = app.reload_portfolio() {
+            app.status_message = Some(format!("Investment load error: {}", err));
         }
         app.calculate_monthly_summaries();
         app.calculate_category_summaries();
@@ -522,6 +567,19 @@ impl App {
 
     pub(crate) fn budget_store(&self) -> SqliteBudgetStore {
         SqliteBudgetStore::new(SqliteDatabase::new(&self.database_path))
+    }
+
+    pub(crate) fn investment_store(&self) -> SqliteInvestmentStore {
+        SqliteInvestmentStore::new(
+            SqliteDatabase::new(&self.database_path),
+            self.active_ledger_id,
+        )
+    }
+
+    pub(crate) fn reload_portfolio(&mut self) -> Result<(), Error> {
+        let store = self.investment_store();
+        self.portfolio = Portfolio::new(store.list_accounts()?, store.list_entries()?);
+        Ok(())
     }
 
     /// One-shot move of the old global target out of config.json into per-ledger history,
@@ -628,6 +686,7 @@ impl App {
     pub(crate) fn reload_working_set(&mut self) -> Result<(), Error> {
         self.reload_categories_from_store()?;
         self.reload_transactions_from_db()?;
+        self.reload_portfolio()?;
         self.refresh_budget_years();
         self.reset_table_selection();
         Ok(())
@@ -976,39 +1035,41 @@ impl App {
                 .select(Some(new_selection));
         }
     }
+    /// Step whichever date field currently has focus, in whatever form is open.
     pub(crate) fn adjust_date(&mut self, amount: i64, unit: DateUnit) {
-        if self.add_edit_fields.focused() == AddEditField::Date {
-            if let Ok(current_date) = NaiveDate::parse_from_str(
-                &self.add_edit_fields[AddEditField::Date],
-                crate::model::DATE_FORMAT,
-            ) {
-                let new_date = match unit {
-                    DateUnit::Day => {
-                        if amount > 0 {
-                            current_date + Duration::days(amount)
-                        } else {
-                            current_date - Duration::days(-amount)
-                        }
-                    }
-                    DateUnit::Month => {
-                        // Use centralized month arithmetic
-                        crate::validation::add_months(current_date, amount as i32)
-                    }
-                };
-                self.add_edit_fields[AddEditField::Date] =
-                    new_date.format(crate::model::DATE_FORMAT).to_string();
-                self.add_edit_cursor = self.add_edit_fields[AddEditField::Date].len();
-                self.clear_status_message() // Clear status on successful adjustment
-            } else {
-                self.set_status_message(
-                    format!(
-                        "Error: Could not parse date '{}'. Use YYYY-MM-DD format.",
-                        self.add_edit_fields[AddEditField::Date]
-                    ),
-                    None,
-                );
+        let Some((content, _)) = self.active_date_input() else {
+            return;
+        };
+        let current = content.clone();
+
+        let Ok(current_date) = NaiveDate::parse_from_str(&current, crate::model::DATE_FORMAT)
+        else {
+            self.set_status_message(
+                format!(
+                    "Error: Could not parse date '{}'. Use YYYY-MM-DD format.",
+                    current
+                ),
+                None,
+            );
+            return;
+        };
+
+        let new_date = match unit {
+            DateUnit::Day => {
+                if amount > 0 {
+                    current_date + Duration::days(amount)
+                } else {
+                    current_date - Duration::days(-amount)
+                }
             }
+            DateUnit::Month => crate::validation::add_months(current_date, amount as i32),
+        };
+
+        if let Some((content, cursor)) = self.active_date_input() {
+            *content = new_date.format(crate::model::DATE_FORMAT).to_string();
+            *cursor = content.len();
         }
+        self.clear_status_message();
     }
     pub fn get_default_data_file_path() -> Result<PathBuf, Error> {
         const DATA_FILE_NAME: &str = "transactions.csv";

--- a/src/db/database.rs
+++ b/src/db/database.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 /// The latest schema version understood by this build. Bump this and add a matching arm in
 /// [`SqliteDatabase::apply_migration`] whenever the schema changes.
-pub const SCHEMA_VERSION: i64 = 4;
+pub const SCHEMA_VERSION: i64 = 5;
 
 #[derive(Debug, Clone)]
 pub struct SqliteDatabase {
@@ -207,6 +207,43 @@ impl SqliteDatabase {
                 }
                 Ok(())
             }
+            // v5: manually tracked investments. Valuations and cash flows are separate rows so
+            // growth is always derived, never typed in.
+            5 => conn
+                .execute_batch(
+                    "
+                    CREATE TABLE IF NOT EXISTS investment_accounts (
+                        id INTEGER PRIMARY KEY,
+                        ledger_id INTEGER NOT NULL REFERENCES ledgers(id) ON DELETE CASCADE,
+                        name TEXT NOT NULL COLLATE NOCASE,
+                        kind TEXT NOT NULL DEFAULT '',
+                        position INTEGER NOT NULL DEFAULT 0,
+                        archived INTEGER NOT NULL DEFAULT 0,
+                        UNIQUE(ledger_id, name)
+                    );
+                    CREATE TABLE IF NOT EXISTS investment_entries (
+                        id INTEGER PRIMARY KEY,
+                        account_id INTEGER NOT NULL
+                            REFERENCES investment_accounts(id) ON DELETE CASCADE,
+                        date TEXT NOT NULL,
+                        entry_kind TEXT NOT NULL
+                            CHECK (entry_kind IN ('Valuation', 'Contribution', 'Withdrawal')),
+                        amount TEXT NOT NULL,
+                        note TEXT NOT NULL DEFAULT '',
+                        -- Reserved for linking a flow to the transaction that funded it.
+                        -- Nothing reads it yet; it is here so adding that needs no migration.
+                        transaction_id INTEGER NULL
+                    );
+                    CREATE INDEX IF NOT EXISTS idx_investment_entries_account
+                        ON investment_entries(account_id, date);
+                    -- Two different values for one account on one day is meaningless, so a
+                    -- second valuation replaces the first rather than stacking.
+                    CREATE UNIQUE INDEX IF NOT EXISTS idx_investment_valuation_day
+                        ON investment_entries(account_id, date)
+                        WHERE entry_kind = 'Valuation';
+                    ",
+                )
+                .map_err(|err| Error::other(format!("Migration v5 failed: {}", err))),
             _ => Ok(()),
         }
     }

--- a/src/db/investment_store.rs
+++ b/src/db/investment_store.rs
@@ -1,0 +1,398 @@
+use crate::db::database::SqliteDatabase;
+use crate::model::{
+    DATE_FORMAT, InvestmentAccount, InvestmentAccountDraft, InvestmentEntry, InvestmentEntryDraft,
+    InvestmentEntryKind,
+};
+use chrono::NaiveDate;
+use rusqlite::{Connection, Row, params};
+use rust_decimal::Decimal;
+use std::io::{Error, ErrorKind, Result};
+use std::str::FromStr;
+
+pub trait InvestmentStore {
+    fn list_accounts(&self) -> Result<Vec<InvestmentAccount>>;
+    fn list_entries(&self) -> Result<Vec<InvestmentEntry>>;
+    fn create_account(&self, draft: &InvestmentAccountDraft) -> Result<i64>;
+    fn update_account(&self, id: i64, draft: &InvestmentAccountDraft) -> Result<()>;
+    fn delete_account(&self, id: i64) -> Result<()>;
+    /// Replaces any valuation the account already has on that date.
+    fn save_entry(&self, draft: &InvestmentEntryDraft) -> Result<i64>;
+    fn update_entry(&self, id: i64, draft: &InvestmentEntryDraft) -> Result<()>;
+    fn delete_entry(&self, id: i64) -> Result<()>;
+}
+
+pub struct SqliteInvestmentStore {
+    database: SqliteDatabase,
+    ledger_id: i64,
+}
+
+impl SqliteInvestmentStore {
+    pub fn new(database: SqliteDatabase, ledger_id: i64) -> Self {
+        Self {
+            database,
+            ledger_id,
+        }
+    }
+
+    fn ready_connection(&self) -> Result<Connection> {
+        self.database.ready_connection("investment")
+    }
+
+    fn row_to_account(row: &Row<'_>) -> rusqlite::Result<InvestmentAccount> {
+        Ok(InvestmentAccount {
+            id: row.get(0)?,
+            name: row.get(1)?,
+            kind: row.get(2)?,
+            position: row.get(3)?,
+            archived: row.get::<_, i64>(4)? != 0,
+        })
+    }
+
+    fn row_to_entry(row: &Row<'_>) -> rusqlite::Result<InvestmentEntry> {
+        Ok(InvestmentEntry {
+            id: row.get(0)?,
+            account_id: row.get(1)?,
+            date: parse_date(2, &row.get::<_, String>(2)?)?,
+            entry_kind: parse_kind(3, &row.get::<_, String>(3)?)?,
+            amount: parse_decimal(4, &row.get::<_, String>(4)?)?,
+            note: row.get(5)?,
+        })
+    }
+
+    fn assert_owns_account(&self, conn: &Connection, account_id: i64) -> Result<()> {
+        let owned: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM investment_accounts WHERE id = ?1 AND ledger_id = ?2",
+                params![account_id, self.ledger_id],
+                |row| row.get(0),
+            )
+            .map_err(|err| Error::other(format!("Failed to check investment account: {}", err)))?;
+
+        if owned == 0 {
+            return Err(Error::new(
+                ErrorKind::NotFound,
+                format!("Investment account {} was not found.", account_id),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl InvestmentStore for SqliteInvestmentStore {
+    fn list_accounts(&self) -> Result<Vec<InvestmentAccount>> {
+        let conn = self.ready_connection()?;
+        let mut stmt = conn
+            .prepare(
+                "
+                SELECT id, name, kind, position, archived
+                FROM investment_accounts
+                WHERE ledger_id = ?1
+                ORDER BY position, id
+                ",
+            )
+            .map_err(|err| Error::other(format!("Failed to prepare account query: {}", err)))?;
+
+        stmt.query_map([self.ledger_id], Self::row_to_account)
+            .map_err(|err| Error::other(format!("Failed to load investment accounts: {}", err)))?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|err| Error::other(format!("Failed to read investment accounts: {}", err)))
+    }
+
+    fn list_entries(&self) -> Result<Vec<InvestmentEntry>> {
+        let conn = self.ready_connection()?;
+        let mut stmt = conn
+            .prepare(
+                "
+                SELECT e.id, e.account_id, e.date, e.entry_kind, e.amount, e.note
+                FROM investment_entries e
+                JOIN investment_accounts a ON a.id = e.account_id
+                WHERE a.ledger_id = ?1
+                ORDER BY e.account_id, e.date, e.id
+                ",
+            )
+            .map_err(|err| Error::other(format!("Failed to prepare entry query: {}", err)))?;
+
+        stmt.query_map([self.ledger_id], Self::row_to_entry)
+            .map_err(|err| Error::other(format!("Failed to load investment entries: {}", err)))?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|err| Error::other(format!("Failed to read investment entries: {}", err)))
+    }
+
+    fn create_account(&self, draft: &InvestmentAccountDraft) -> Result<i64> {
+        let name = validate_name(&draft.name)?;
+        let conn = self.ready_connection()?;
+        let position: i64 = conn
+            .query_row(
+                "SELECT COALESCE(MAX(position), -1) + 1 FROM investment_accounts WHERE ledger_id = ?1",
+                [self.ledger_id],
+                |row| row.get(0),
+            )
+            .map_err(|err| Error::other(format!("Failed to position new account: {}", err)))?;
+
+        conn.execute(
+            "
+            INSERT INTO investment_accounts (ledger_id, name, kind, position, archived)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            ",
+            params![
+                self.ledger_id,
+                &name,
+                draft.kind.trim(),
+                position,
+                draft.archived as i64
+            ],
+        )
+        .map_err(|err| name_conflict(err, &name, "create"))?;
+
+        Ok(conn.last_insert_rowid())
+    }
+
+    fn update_account(&self, id: i64, draft: &InvestmentAccountDraft) -> Result<()> {
+        let name = validate_name(&draft.name)?;
+        let conn = self.ready_connection()?;
+        let updated = conn
+            .execute(
+                "
+                UPDATE investment_accounts
+                SET name = ?1, kind = ?2, archived = ?3
+                WHERE id = ?4 AND ledger_id = ?5
+                ",
+                params![
+                    &name,
+                    draft.kind.trim(),
+                    draft.archived as i64,
+                    id,
+                    self.ledger_id
+                ],
+            )
+            .map_err(|err| name_conflict(err, &name, "rename"))?;
+
+        if updated == 0 {
+            return Err(Error::new(
+                ErrorKind::NotFound,
+                format!("Investment account {} was not found.", id),
+            ));
+        }
+        Ok(())
+    }
+
+    fn delete_account(&self, id: i64) -> Result<()> {
+        let conn = self.ready_connection()?;
+        let deleted = conn
+            .execute(
+                "DELETE FROM investment_accounts WHERE id = ?1 AND ledger_id = ?2",
+                params![id, self.ledger_id],
+            )
+            .map_err(|err| Error::other(format!("Failed to delete investment account: {}", err)))?;
+
+        if deleted == 0 {
+            return Err(Error::new(
+                ErrorKind::NotFound,
+                format!("Investment account {} was not found.", id),
+            ));
+        }
+        Ok(())
+    }
+
+    fn save_entry(&self, draft: &InvestmentEntryDraft) -> Result<i64> {
+        let amount = validate_amount(draft.amount, draft.entry_kind)?;
+        let mut conn = self.ready_connection()?;
+        self.assert_owns_account(&conn, draft.account_id)?;
+
+        let tx = conn
+            .transaction()
+            .map_err(|err| Error::other(format!("Failed to begin entry write: {}", err)))?;
+
+        // A partial unique index can't be an ON CONFLICT target, so clear then insert.
+        if draft.entry_kind == InvestmentEntryKind::Valuation {
+            tx.execute(
+                "
+                DELETE FROM investment_entries
+                WHERE account_id = ?1 AND date = ?2 AND entry_kind = 'Valuation'
+                ",
+                params![draft.account_id, draft.date.format(DATE_FORMAT).to_string()],
+            )
+            .map_err(|err| Error::other(format!("Failed to replace valuation: {}", err)))?;
+        }
+
+        tx.execute(
+            "
+            INSERT INTO investment_entries (account_id, date, entry_kind, amount, note)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            ",
+            params![
+                draft.account_id,
+                draft.date.format(DATE_FORMAT).to_string(),
+                draft.entry_kind.as_str(),
+                amount.to_string(),
+                draft.note.trim()
+            ],
+        )
+        .map_err(|err| Error::other(format!("Failed to save investment entry: {}", err)))?;
+
+        let id = tx.last_insert_rowid();
+        tx.commit()
+            .map_err(|err| Error::other(format!("Failed to commit entry write: {}", err)))?;
+        Ok(id)
+    }
+
+    fn update_entry(&self, id: i64, draft: &InvestmentEntryDraft) -> Result<()> {
+        let amount = validate_amount(draft.amount, draft.entry_kind)?;
+        let mut conn = self.ready_connection()?;
+        self.assert_owns_account(&conn, draft.account_id)?;
+
+        let tx = conn
+            .transaction()
+            .map_err(|err| Error::other(format!("Failed to begin entry update: {}", err)))?;
+
+        if draft.entry_kind == InvestmentEntryKind::Valuation {
+            tx.execute(
+                "
+                DELETE FROM investment_entries
+                WHERE account_id = ?1 AND date = ?2 AND entry_kind = 'Valuation' AND id != ?3
+                ",
+                params![
+                    draft.account_id,
+                    draft.date.format(DATE_FORMAT).to_string(),
+                    id
+                ],
+            )
+            .map_err(|err| Error::other(format!("Failed to replace valuation: {}", err)))?;
+        }
+
+        let updated = tx
+            .execute(
+                "
+                UPDATE investment_entries
+                SET account_id = ?1, date = ?2, entry_kind = ?3, amount = ?4, note = ?5
+                WHERE id = ?6
+                ",
+                params![
+                    draft.account_id,
+                    draft.date.format(DATE_FORMAT).to_string(),
+                    draft.entry_kind.as_str(),
+                    amount.to_string(),
+                    draft.note.trim(),
+                    id
+                ],
+            )
+            .map_err(|err| Error::other(format!("Failed to update investment entry: {}", err)))?;
+
+        if updated == 0 {
+            return Err(Error::new(
+                ErrorKind::NotFound,
+                format!("Investment entry {} was not found.", id),
+            ));
+        }
+
+        tx.commit()
+            .map_err(|err| Error::other(format!("Failed to commit entry update: {}", err)))
+    }
+
+    fn delete_entry(&self, id: i64) -> Result<()> {
+        let conn = self.ready_connection()?;
+        let deleted = conn
+            .execute(
+                "
+                DELETE FROM investment_entries
+                WHERE id = ?1 AND account_id IN (
+                    SELECT id FROM investment_accounts WHERE ledger_id = ?2
+                )
+                ",
+                params![id, self.ledger_id],
+            )
+            .map_err(|err| Error::other(format!("Failed to delete investment entry: {}", err)))?;
+
+        if deleted == 0 {
+            return Err(Error::new(
+                ErrorKind::NotFound,
+                format!("Investment entry {} was not found.", id),
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn validate_name(name: &str) -> Result<String> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "Account name cannot be empty.",
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+/// Zero is a real valuation (you sold out) but never a real flow.
+fn validate_amount(amount: Decimal, kind: InvestmentEntryKind) -> Result<Decimal> {
+    if amount < Decimal::ZERO {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "Amount cannot be negative. Use a withdrawal to take money out.",
+        ));
+    }
+    if amount.is_zero() && kind != InvestmentEntryKind::Valuation {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            format!("A {} needs an amount.", kind.as_str().to_lowercase()),
+        ));
+    }
+    Ok(amount)
+}
+
+fn name_conflict(err: rusqlite::Error, name: &str, action: &str) -> Error {
+    match err {
+        rusqlite::Error::SqliteFailure(inner, _)
+            if inner.code == rusqlite::ErrorCode::ConstraintViolation =>
+        {
+            Error::new(
+                ErrorKind::AlreadyExists,
+                format!("An investment account named '{}' already exists.", name),
+            )
+        }
+        other => Error::other(format!(
+            "Failed to {} investment account: {}",
+            action, other
+        )),
+    }
+}
+
+fn parse_date(index: usize, value: &str) -> rusqlite::Result<NaiveDate> {
+    NaiveDate::parse_from_str(value, DATE_FORMAT).map_err(|err| {
+        rusqlite::Error::FromSqlConversionFailure(
+            index,
+            rusqlite::types::Type::Text,
+            Box::new(Error::new(
+                ErrorKind::InvalidData,
+                format!("Invalid date '{}' in investment database: {}", value, err),
+            )),
+        )
+    })
+}
+
+fn parse_decimal(index: usize, value: &str) -> rusqlite::Result<Decimal> {
+    Decimal::from_str(value.trim()).map_err(|err| {
+        rusqlite::Error::FromSqlConversionFailure(
+            index,
+            rusqlite::types::Type::Text,
+            Box::new(Error::new(
+                ErrorKind::InvalidData,
+                format!("Invalid amount '{}' in investment database: {}", value, err),
+            )),
+        )
+    })
+}
+
+fn parse_kind(index: usize, value: &str) -> rusqlite::Result<InvestmentEntryKind> {
+    InvestmentEntryKind::from_label(value).ok_or_else(|| {
+        rusqlite::Error::FromSqlConversionFailure(
+            index,
+            rusqlite::types::Type::Text,
+            Box::new(Error::new(
+                ErrorKind::InvalidData,
+                format!("Invalid entry kind '{}' in investment database.", value),
+            )),
+        )
+    })
+}

--- a/src/db/investment_store.rs
+++ b/src/db/investment_store.rs
@@ -265,7 +265,9 @@ impl InvestmentStore for SqliteInvestmentStore {
                 "
                 UPDATE investment_entries
                 SET account_id = ?1, date = ?2, entry_kind = ?3, amount = ?4, note = ?5
-                WHERE id = ?6
+                WHERE id = ?6 AND account_id IN (
+                    SELECT id FROM investment_accounts WHERE ledger_id = ?7
+                )
                 ",
                 params![
                     draft.account_id,
@@ -273,7 +275,8 @@ impl InvestmentStore for SqliteInvestmentStore {
                     draft.entry_kind.as_str(),
                     amount.to_string(),
                     draft.note.trim(),
-                    id
+                    id,
+                    self.ledger_id
                 ],
             )
             .map_err(|err| Error::other(format!("Failed to update investment entry: {}", err)))?;

--- a/src/db/ledger_store.rs
+++ b/src/db/ledger_store.rs
@@ -31,7 +31,7 @@ pub trait LedgerStore {
     /// Create a ledger holding a copy of every transaction in `source_id`.
     fn copy(&self, source_id: i64, name: &str) -> Result<LedgerRecord>;
     fn rename(&self, id: i64, name: &str) -> Result<()>;
-    /// Delete a ledger and every transaction it holds. Refuses to delete the last ledger.
+    /// Delete a ledger and everything it holds. Refuses to delete the last ledger.
     fn delete(&self, id: i64) -> Result<()>;
     fn transaction_count(&self, id: i64) -> Result<i64>;
     fn set_active_id(&self, id: i64) -> Result<()>;
@@ -189,6 +189,33 @@ impl LedgerStore for SqliteLedgerStore {
         )
         .map_err(|err| Error::other(format!("Failed to copy budgets: {}", err)))?;
 
+        // Accounts first, then their entries remapped onto the new ids.
+        tx.execute(
+            "
+            INSERT INTO investment_accounts (ledger_id, name, kind, position, archived)
+            SELECT ?1, name, kind, position, archived
+            FROM investment_accounts
+            WHERE ledger_id = ?2
+            ",
+            params![ledger.id, source_id],
+        )
+        .map_err(|err| Error::other(format!("Failed to copy investment accounts: {}", err)))?;
+
+        tx.execute(
+            "
+            INSERT INTO investment_entries
+                (account_id, date, entry_kind, amount, note, transaction_id)
+            SELECT copy.id, e.date, e.entry_kind, e.amount, e.note, e.transaction_id
+            FROM investment_entries e
+            JOIN investment_accounts source ON source.id = e.account_id
+            JOIN investment_accounts copy
+                ON copy.ledger_id = ?1 AND copy.name = source.name
+            WHERE source.ledger_id = ?2
+            ",
+            params![ledger.id, source_id],
+        )
+        .map_err(|err| Error::other(format!("Failed to copy investment entries: {}", err)))?;
+
         tx.commit()
             .map_err(|err| Error::other(format!("Failed to commit ledger copy: {}", err)))?;
         Ok(ledger)
@@ -243,6 +270,20 @@ impl LedgerStore for SqliteLedgerStore {
         tx.execute("DELETE FROM transactions WHERE ledger_id = ?1", [id])
             .map_err(|err| {
                 Error::other(format!("Failed to delete ledger transactions: {}", err))
+            })?;
+        // Entries go through the accounts' cascade, but only if foreign keys are on for this
+        // connection, so clear them explicitly rather than relying on the pragma.
+        tx.execute(
+            "
+            DELETE FROM investment_entries
+            WHERE account_id IN (SELECT id FROM investment_accounts WHERE ledger_id = ?1)
+            ",
+            [id],
+        )
+        .map_err(|err| Error::other(format!("Failed to delete investment entries: {}", err)))?;
+        tx.execute("DELETE FROM investment_accounts WHERE ledger_id = ?1", [id])
+            .map_err(|err| {
+                Error::other(format!("Failed to delete investment accounts: {}", err))
             })?;
         let deleted = tx
             .execute("DELETE FROM ledgers WHERE id = ?1", [id])

--- a/src/db/ledger_store.rs
+++ b/src/db/ledger_store.rs
@@ -34,6 +34,7 @@ pub trait LedgerStore {
     /// Delete a ledger and everything it holds. Refuses to delete the last ledger.
     fn delete(&self, id: i64) -> Result<()>;
     fn transaction_count(&self, id: i64) -> Result<i64>;
+    fn investment_account_count(&self, id: i64) -> Result<i64>;
     fn set_active_id(&self, id: i64) -> Result<()>;
 }
 
@@ -308,6 +309,16 @@ impl LedgerStore for SqliteLedgerStore {
             |row| row.get(0),
         )
         .map_err(|err| Error::other(format!("Failed to count ledger transactions: {}", err)))
+    }
+
+    fn investment_account_count(&self, id: i64) -> Result<i64> {
+        let conn = self.ready_connection()?;
+        conn.query_row(
+            "SELECT COUNT(*) FROM investment_accounts WHERE ledger_id = ?1",
+            [id],
+            |row| row.get(0),
+        )
+        .map_err(|err| Error::other(format!("Failed to count investment accounts: {}", err)))
     }
 
     fn set_active_id(&self, id: i64) -> Result<()> {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,5 +1,6 @@
 pub mod budget_store;
 pub mod category_store;
 pub mod database;
+pub mod investment_store;
 pub mod ledger_store;
 pub mod transaction_store;

--- a/src/db/transaction_store.rs
+++ b/src/db/transaction_store.rs
@@ -320,8 +320,12 @@ mod tests {
     use super::*;
     use crate::db::category_store::CategoryStore;
     use crate::db::database::SCHEMA_VERSION;
+    use crate::db::investment_store::{InvestmentStore, SqliteInvestmentStore};
     use crate::db::ledger_store::{DEFAULT_LEDGER_ID, LedgerStore, SqliteLedgerStore};
-    use crate::model::BudgetSchedule;
+    use crate::model::{
+        BudgetSchedule, InvestmentAccountDraft, InvestmentEntryDraft, InvestmentEntryKind,
+        Portfolio,
+    };
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -850,6 +854,140 @@ mod tests {
             schedule.category_budget(record.id, BudgetMonth::new(2026, 6)),
             None
         );
+    }
+
+    fn investments(temp: &TempDb, ledger_id: i64) -> SqliteInvestmentStore {
+        SqliteInvestmentStore::new(SqliteDatabase::new(&temp.path), ledger_id)
+    }
+
+    fn entry(
+        account_id: i64,
+        date: &str,
+        entry_kind: InvestmentEntryKind,
+        amount: &str,
+    ) -> InvestmentEntryDraft {
+        InvestmentEntryDraft {
+            account_id,
+            date: NaiveDate::parse_from_str(date, DATE_FORMAT).unwrap(),
+            entry_kind,
+            amount: Decimal::from_str(amount).unwrap(),
+            note: String::new(),
+        }
+    }
+
+    fn day(date: &str) -> NaiveDate {
+        NaiveDate::parse_from_str(date, DATE_FORMAT).unwrap()
+    }
+
+    /// The identity the whole investments view rests on: money paid in is never growth.
+    #[test]
+    fn contributions_are_never_counted_as_investment_growth() {
+        let temp = TempDb::new();
+        let store = investments(&temp, DEFAULT_LEDGER_ID);
+        let account = store
+            .create_account(&InvestmentAccountDraft {
+                name: "TFSA".to_string(),
+                kind: "Brokerage".to_string(),
+                archived: false,
+            })
+            .unwrap();
+
+        // Opening position, then a deposit, then a fresh valuation.
+        store
+            .save_entry(&entry(
+                account,
+                "2024-01-01",
+                InvestmentEntryKind::Contribution,
+                "10000",
+            ))
+            .unwrap();
+        store
+            .save_entry(&entry(
+                account,
+                "2024-01-01",
+                InvestmentEntryKind::Valuation,
+                "10000",
+            ))
+            .unwrap();
+        store
+            .save_entry(&entry(
+                account,
+                "2024-07-01",
+                InvestmentEntryKind::Contribution,
+                "5000",
+            ))
+            .unwrap();
+        store
+            .save_entry(&entry(
+                account,
+                "2025-01-01",
+                InvestmentEntryKind::Valuation,
+                "17000",
+            ))
+            .unwrap();
+
+        let portfolio = Portfolio::new(
+            store.list_accounts().unwrap(),
+            store.list_entries().unwrap(),
+        );
+
+        // Between the deposit and the next valuation the money shows up as value, not gain.
+        assert_eq!(
+            portfolio.value_on(account, day("2024-08-01")),
+            Decimal::from(15000)
+        );
+        assert_eq!(
+            portfolio.gain_between(Some(account), day("2024-01-01"), day("2024-08-01"), false),
+            Decimal::ZERO
+        );
+
+        // Over the full span only the 2,000 the account actually earned counts.
+        let position = portfolio.position(account, day("2025-01-01"));
+        assert_eq!(position.value, Decimal::from(17000));
+        assert_eq!(position.invested, Decimal::from(15000));
+        assert_eq!(position.gain(), Decimal::from(2000));
+        assert_eq!(
+            portfolio.gain_between(Some(account), day("2024-01-01"), day("2025-01-01"), false),
+            Decimal::from(2000)
+        );
+    }
+
+    #[test]
+    fn copying_a_ledger_carries_its_investments_and_deleting_one_clears_them() {
+        let temp = TempDb::new();
+        let source = investments(&temp, DEFAULT_LEDGER_ID);
+        let account = source
+            .create_account(&InvestmentAccountDraft {
+                name: "Brokerage".to_string(),
+                kind: "Taxable".to_string(),
+                archived: false,
+            })
+            .unwrap();
+        source
+            .save_entry(&entry(
+                account,
+                "2025-01-01",
+                InvestmentEntryKind::Contribution,
+                "500",
+            ))
+            .unwrap();
+
+        let ledger_store = SqliteLedgerStore::new(SqliteDatabase::new(&temp.path));
+        let copy = ledger_store.copy(DEFAULT_LEDGER_ID, "Copy").unwrap();
+
+        let copied = investments(&temp, copy.id);
+        assert_eq!(copied.list_accounts().unwrap().len(), 1);
+        let copied_entries = copied.list_entries().unwrap();
+        assert_eq!(copied_entries.len(), 1);
+        assert_eq!(copied_entries[0].amount, Decimal::from(500));
+        // The copy stands on its own rows, not the source's.
+        assert_ne!(copied_entries[0].account_id, account);
+
+        ledger_store.delete(copy.id).unwrap();
+        assert!(copied.list_accounts().unwrap().is_empty());
+        assert!(copied.list_entries().unwrap().is_empty());
+        // The ledger that was copied from is untouched.
+        assert_eq!(source.list_entries().unwrap().len(), 1);
     }
 
     #[test]

--- a/src/events/investments_mode.rs
+++ b/src/events/investments_mode.rs
@@ -1,0 +1,173 @@
+use crate::app::fields::{FieldKey, FieldKind, InvestmentAccountField, InvestmentEntryField};
+use crate::app::state::{App, AppMode};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+pub fn handle_investments_mode(app: &mut App, key_event: KeyEvent) {
+    match app.mode {
+        AppMode::Investments => handle_overview(app, key_event),
+        AppMode::InvestmentDetail => handle_detail(app, key_event),
+        AppMode::InvestmentAccountEditor => handle_account_editor(app, key_event),
+        AppMode::InvestmentEntryEditor => handle_entry_editor(app, key_event),
+        AppMode::ConfirmInvestmentDelete => handle_confirm_delete(app, key_event),
+        _ => {}
+    }
+}
+
+fn handle_overview(app: &mut App, key_event: KeyEvent) {
+    match (key_event.code, key_event.modifiers) {
+        (KeyCode::Char('q'), _) | (KeyCode::Esc, _) => app.exit_investments_mode(),
+        (KeyCode::Down, KeyModifiers::NONE) => app.next_investment_account(),
+        (KeyCode::Up, KeyModifiers::NONE) => app.previous_investment_account(),
+        (KeyCode::Right, KeyModifiers::NONE) => app.cycle_investment_range(true),
+        (KeyCode::Left, KeyModifiers::NONE) => app.cycle_investment_range(false),
+        (KeyCode::Enter, KeyModifiers::NONE) => app.open_investment_detail(),
+        (KeyCode::Char('a'), KeyModifiers::NONE) => app.start_adding_investment_account(),
+        (KeyCode::Char('e'), KeyModifiers::NONE) => app.start_editing_investment_account(),
+        (KeyCode::Char('d'), KeyModifiers::NONE) => app.prepare_delete_investment(),
+        (KeyCode::Char('v'), KeyModifiers::NONE) => app.start_recording_valuation(),
+        (KeyCode::Char('A'), _) => app.toggle_archived_investments(),
+        _ => {}
+    }
+}
+
+fn handle_detail(app: &mut App, key_event: KeyEvent) {
+    match (key_event.code, key_event.modifiers) {
+        (KeyCode::Char('q'), _) | (KeyCode::Esc, _) => app.exit_investment_detail(),
+        (KeyCode::Down, KeyModifiers::NONE) => app.next_investment_entry(),
+        (KeyCode::Up, KeyModifiers::NONE) => app.previous_investment_entry(),
+        (KeyCode::Right, KeyModifiers::NONE) => app.cycle_investment_range(true),
+        (KeyCode::Left, KeyModifiers::NONE) => app.cycle_investment_range(false),
+        // a/e/d follow the rows on screen, which here are entries.
+        (KeyCode::Char('a'), KeyModifiers::NONE) => app.start_adding_investment_entry(),
+        (KeyCode::Char('e'), KeyModifiers::NONE) | (KeyCode::Enter, KeyModifiers::NONE) => {
+            app.start_editing_investment_entry()
+        }
+        (KeyCode::Char('d'), KeyModifiers::NONE) => app.prepare_delete_investment(),
+        (KeyCode::Char('v'), KeyModifiers::NONE) => app.start_recording_valuation(),
+        _ => {}
+    }
+}
+
+fn handle_account_editor(app: &mut App, key_event: KeyEvent) {
+    let focused = app.investment_account_fields.focused();
+    let inert = !app.investment_opening_fields_active()
+        && matches!(
+            focused,
+            InvestmentAccountField::OpeningValue
+                | InvestmentAccountField::OpeningInvested
+                | InvestmentAccountField::OpeningDate
+        );
+
+    match (key_event.code, key_event.modifiers) {
+        (KeyCode::Esc, KeyModifiers::NONE) => app.cancel_investment_account_editor(),
+        (KeyCode::Tab, KeyModifiers::NONE) | (KeyCode::Down, KeyModifiers::NONE) => {
+            app.next_investment_account_field()
+        }
+        (KeyCode::BackTab, KeyModifiers::NONE) | (KeyCode::Up, KeyModifiers::NONE) => {
+            app.previous_investment_account_field()
+        }
+        (KeyCode::Enter, KeyModifiers::NONE) => match focused {
+            InvestmentAccountField::Status => app.toggle_investment_status(),
+            _ => app.save_investment_account(),
+        },
+        (KeyCode::Left, KeyModifiers::NONE) => match focused {
+            InvestmentAccountField::Status => app.toggle_investment_status(),
+            InvestmentAccountField::OpeningDate if !inert => app.decrement_date(),
+            _ => app.move_cursor_left(),
+        },
+        (KeyCode::Right, KeyModifiers::NONE) => match focused {
+            InvestmentAccountField::Status => app.toggle_investment_status(),
+            InvestmentAccountField::OpeningDate if !inert => app.increment_date(),
+            _ => app.move_cursor_right(),
+        },
+        (KeyCode::Left, KeyModifiers::SHIFT)
+            if focused == InvestmentAccountField::OpeningDate && !inert =>
+        {
+            app.decrement_month()
+        }
+        (KeyCode::Right, KeyModifiers::SHIFT)
+            if focused == InvestmentAccountField::OpeningDate && !inert =>
+        {
+            app.increment_month()
+        }
+        (KeyCode::Char(_), _) | (KeyCode::Backspace, _) | (KeyCode::Delete, _) if inert => {}
+        (KeyCode::Char(c), KeyModifiers::NONE) => match focused.kind() {
+            FieldKind::Date if c == '+' || c == '=' => app.increment_date(),
+            FieldKind::Date if c == '-' => app.decrement_date(),
+            FieldKind::Date if c.is_ascii_digit() => app.insert_char_at_cursor(c),
+            FieldKind::Date => {}
+            kind if !kind.is_editable() => {}
+            _ => app.insert_char_at_cursor(c),
+        },
+        (KeyCode::Char(c), KeyModifiers::SHIFT) if focused.kind() == FieldKind::Text => {
+            app.insert_char_at_cursor(c)
+        }
+        (KeyCode::Backspace, KeyModifiers::NONE) if focused.kind().is_editable() => {
+            app.delete_char_before_cursor()
+        }
+        (KeyCode::Delete, KeyModifiers::NONE) if focused.kind().is_editable() => {
+            app.delete_char_after_cursor()
+        }
+        _ => {}
+    }
+}
+
+fn handle_entry_editor(app: &mut App, key_event: KeyEvent) {
+    let focused = app.investment_entry_fields.focused();
+
+    match (key_event.code, key_event.modifiers) {
+        (KeyCode::Esc, KeyModifiers::NONE) => app.cancel_investment_entry_editor(),
+        (KeyCode::Tab, KeyModifiers::NONE) | (KeyCode::Down, KeyModifiers::NONE) => {
+            app.next_investment_entry_field()
+        }
+        (KeyCode::BackTab, KeyModifiers::NONE) | (KeyCode::Up, KeyModifiers::NONE) => {
+            app.previous_investment_entry_field()
+        }
+        (KeyCode::Enter, KeyModifiers::NONE) => match focused {
+            InvestmentEntryField::EntryKind => app.cycle_investment_entry_kind(true),
+            _ => app.save_investment_entry(),
+        },
+        (KeyCode::Left, KeyModifiers::NONE) => match focused {
+            InvestmentEntryField::EntryKind => app.cycle_investment_entry_kind(false),
+            InvestmentEntryField::Date => app.decrement_date(),
+            _ => app.move_cursor_left(),
+        },
+        (KeyCode::Right, KeyModifiers::NONE) => match focused {
+            InvestmentEntryField::EntryKind => app.cycle_investment_entry_kind(true),
+            InvestmentEntryField::Date => app.increment_date(),
+            _ => app.move_cursor_right(),
+        },
+        (KeyCode::Left, KeyModifiers::SHIFT) if focused == InvestmentEntryField::Date => {
+            app.decrement_month()
+        }
+        (KeyCode::Right, KeyModifiers::SHIFT) if focused == InvestmentEntryField::Date => {
+            app.increment_month()
+        }
+        (KeyCode::Char(c), KeyModifiers::NONE) => match focused.kind() {
+            FieldKind::Date if c == '+' || c == '=' => app.increment_date(),
+            FieldKind::Date if c == '-' => app.decrement_date(),
+            FieldKind::Date if c.is_ascii_digit() => app.insert_char_at_cursor(c),
+            FieldKind::Date => {}
+            kind if !kind.is_editable() => {}
+            _ => app.insert_char_at_cursor(c),
+        },
+        (KeyCode::Char(c), KeyModifiers::SHIFT) if focused.kind() == FieldKind::Text => {
+            app.insert_char_at_cursor(c)
+        }
+        (KeyCode::Backspace, KeyModifiers::NONE) if focused.kind().is_editable() => {
+            app.delete_char_before_cursor()
+        }
+        (KeyCode::Delete, KeyModifiers::NONE) if focused.kind().is_editable() => {
+            app.delete_char_after_cursor()
+        }
+        _ => {}
+    }
+}
+
+fn handle_confirm_delete(app: &mut App, key_event: KeyEvent) {
+    match key_event.code {
+        KeyCode::Char('y') | KeyCode::Char('Y') => app.confirm_delete_investment(),
+        KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => app.cancel_delete_investment(),
+        _ => {}
+    }
+}

--- a/src/events/mod.rs
+++ b/src/events/mod.rs
@@ -4,6 +4,7 @@ mod category_manager_mode;
 mod filter_mode;
 mod fuzzy_search_mode;
 mod help_mode;
+mod investments_mode;
 mod ledger_manager_mode;
 mod normal_mode;
 mod recurring_mode;

--- a/src/events/normal_mode.rs
+++ b/src/events/normal_mode.rs
@@ -33,6 +33,7 @@ pub fn handle_normal_mode(app: &mut App, key_event: KeyEvent) {
         (KeyCode::Char('c'), KeyModifiers::CONTROL) => app.copy_transaction(),
         (KeyCode::Char('c'), _) => app.enter_category_summary_mode(),
         (KeyCode::Char('b'), _) => app.enter_budget_mode(),
+        (KeyCode::Char('i'), _) => app.enter_investments_mode(),
         (KeyCode::Char('o'), _) => app.enter_settings_mode(),
         // Sorting
         (KeyCode::Char('1'), _) | (KeyCode::F(1), _) => app.set_sort_column(SortColumn::Date),

--- a/src/events/runner.rs
+++ b/src/events/runner.rs
@@ -8,8 +8,8 @@ use std::time::Duration;
 
 use super::{
     add_edit_mode, budget_mode, category_manager_mode, filter_mode, fuzzy_search_mode, help_mode,
-    ledger_manager_mode, normal_mode, recurring_mode, selection_mode, settings_mode, summary_mode,
-    transaction_io_mode,
+    investments_mode, ledger_manager_mode, normal_mode, recurring_mode, selection_mode,
+    settings_mode, summary_mode, transaction_io_mode,
 };
 
 pub fn run_app<B: Backend>(
@@ -64,9 +64,10 @@ where
                                 // Allow Shift+Char in Adding, Editing and FuzzyFinding modes
                                 || ((app.mode == AppMode::Adding || app.mode == AppMode::Editing || app.mode == AppMode::FuzzyFinding || app.mode == AppMode::CategoryEditor || app.mode == AppMode::CategoryCatalogFilter || app.mode == AppMode::LedgerEditor) && key.modifiers == KeyModifiers::SHIFT && matches!(key.code, KeyCode::Char(_)))
                                 // Allow Shift+Arrow in date-like navigation modes
-                                || ((app.mode == AppMode::Adding || app.mode == AppMode::Editing || app.mode == AppMode::AdvancedFiltering || app.mode == AppMode::RecurringSettings || app.mode == AppMode::Budget)
+                                || ((app.mode == AppMode::Adding || app.mode == AppMode::Editing || app.mode == AppMode::AdvancedFiltering || app.mode == AppMode::RecurringSettings || app.mode == AppMode::Budget || app.mode == AppMode::InvestmentAccountEditor || app.mode == AppMode::InvestmentEntryEditor)
                                     && key.modifiers == KeyModifiers::SHIFT
                                     && matches!(key.code, KeyCode::Left | KeyCode::Right))
+                                || ((app.mode == AppMode::InvestmentAccountEditor || app.mode == AppMode::InvestmentEntryEditor || app.mode == AppMode::Investments) && key.modifiers == KeyModifiers::SHIFT && matches!(key.code, KeyCode::Char(_)))
                                 // Allow Ctrl+F/R in simple Filtering mode and Ctrl+R in AdvancedFiltering mode
                                 || (app.mode == AppMode::Filtering && key.modifiers == KeyModifiers::CONTROL && matches!(key.code, KeyCode::Char('f') | KeyCode::Char('r')))
                                 || (app.mode == AppMode::AdvancedFiltering && key.modifiers == KeyModifiers::CONTROL && matches!(key.code, KeyCode::Char('r')))
@@ -191,6 +192,13 @@ fn update(app: &mut App, key_event: KeyEvent) {
         }
         AppMode::LedgerManager | AppMode::LedgerEditor | AppMode::ConfirmLedgerDelete => {
             ledger_manager_mode::handle_ledger_manager_mode(app, key_event)
+        }
+        AppMode::Investments
+        | AppMode::InvestmentDetail
+        | AppMode::InvestmentAccountEditor
+        | AppMode::InvestmentEntryEditor
+        | AppMode::ConfirmInvestmentDelete => {
+            investments_mode::handle_investments_mode(app, key_event)
         }
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,5 +1,6 @@
-use chrono::NaiveDate;
+use chrono::{Datelike, Duration, NaiveDate};
 use rust_decimal::Decimal;
+use rust_decimal::prelude::ToPrimitive;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -470,5 +471,483 @@ impl CategoryRecord {
             subcategory: self.subcategory.clone(),
             tag: self.tag.clone(),
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvestmentEntryKind {
+    Valuation,
+    Contribution,
+    Withdrawal,
+}
+
+impl InvestmentEntryKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            InvestmentEntryKind::Valuation => "Valuation",
+            InvestmentEntryKind::Contribution => "Contribution",
+            InvestmentEntryKind::Withdrawal => "Withdrawal",
+        }
+    }
+
+    pub fn from_label(label: &str) -> Option<InvestmentEntryKind> {
+        match label {
+            "Valuation" => Some(InvestmentEntryKind::Valuation),
+            "Contribution" => Some(InvestmentEntryKind::Contribution),
+            "Withdrawal" => Some(InvestmentEntryKind::Withdrawal),
+            _ => None,
+        }
+    }
+
+    pub fn all() -> [InvestmentEntryKind; 3] {
+        [
+            InvestmentEntryKind::Valuation,
+            InvestmentEntryKind::Contribution,
+            InvestmentEntryKind::Withdrawal,
+        ]
+    }
+
+    pub fn flow_sign(self) -> Decimal {
+        match self {
+            InvestmentEntryKind::Valuation => Decimal::ZERO,
+            InvestmentEntryKind::Contribution => Decimal::ONE,
+            InvestmentEntryKind::Withdrawal => Decimal::NEGATIVE_ONE,
+        }
+    }
+}
+
+impl fmt::Display for InvestmentEntryKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvestmentAccount {
+    pub id: i64,
+    pub name: String,
+    pub kind: String,
+    pub position: i64,
+    pub archived: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvestmentAccountDraft {
+    pub name: String,
+    pub kind: String,
+    pub archived: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvestmentEntry {
+    pub id: i64,
+    pub account_id: i64,
+    pub date: NaiveDate,
+    pub entry_kind: InvestmentEntryKind,
+    pub amount: Decimal,
+    pub note: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvestmentEntryDraft {
+    pub account_id: i64,
+    pub date: NaiveDate,
+    pub entry_kind: InvestmentEntryKind,
+    pub amount: Decimal,
+    pub note: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InvestmentRange {
+    Ytd,
+    OneYear,
+    ThreeYears,
+    FiveYears,
+    All,
+}
+
+impl InvestmentRange {
+    pub fn label(self) -> &'static str {
+        match self {
+            InvestmentRange::Ytd => "YTD",
+            InvestmentRange::OneYear => "1Y",
+            InvestmentRange::ThreeYears => "3Y",
+            InvestmentRange::FiveYears => "5Y",
+            InvestmentRange::All => "All",
+        }
+    }
+
+    pub fn all() -> [InvestmentRange; 5] {
+        [
+            InvestmentRange::Ytd,
+            InvestmentRange::OneYear,
+            InvestmentRange::ThreeYears,
+            InvestmentRange::FiveYears,
+            InvestmentRange::All,
+        ]
+    }
+
+    pub fn requested_start(self, today: NaiveDate) -> Option<NaiveDate> {
+        match self {
+            // Last New Year's Eve, not Jan 1, or a move on Jan 1 falls outside the year.
+            InvestmentRange::Ytd => NaiveDate::from_ymd_opt(today.year() - 1, 12, 31),
+            InvestmentRange::OneYear => Some(crate::validation::add_months(today, -12)),
+            InvestmentRange::ThreeYears => Some(crate::validation::add_months(today, -36)),
+            InvestmentRange::FiveYears => Some(crate::validation::add_months(today, -60)),
+            InvestmentRange::All => None,
+        }
+    }
+
+    pub fn start(self, today: NaiveDate, earliest: Option<NaiveDate>) -> NaiveDate {
+        let floor = earliest.unwrap_or(today);
+        match self.requested_start(today) {
+            Some(requested) => requested.max(floor),
+            None => floor,
+        }
+    }
+
+    pub fn crops(self, today: NaiveDate, earliest: Option<NaiveDate>) -> bool {
+        match (self.requested_start(today), earliest) {
+            (Some(requested), Some(first)) => requested > first,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Portfolio {
+    accounts: Vec<InvestmentAccount>,
+    entries: Vec<InvestmentEntry>,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct InvestmentPosition {
+    pub value: Decimal,
+    pub invested: Decimal,
+    pub as_of: Option<NaiveDate>,
+}
+
+impl InvestmentPosition {
+    pub fn gain(&self) -> Decimal {
+        self.value - self.invested
+    }
+
+    pub fn roi(&self) -> Option<Decimal> {
+        (self.invested > Decimal::ZERO).then(|| (self.gain() / self.invested) * Decimal::from(100))
+    }
+}
+
+impl Portfolio {
+    pub fn new(mut accounts: Vec<InvestmentAccount>, mut entries: Vec<InvestmentEntry>) -> Self {
+        accounts.sort_by(|a, b| a.position.cmp(&b.position).then_with(|| a.id.cmp(&b.id)));
+        entries.sort_by(|a, b| {
+            a.account_id
+                .cmp(&b.account_id)
+                .then_with(|| a.date.cmp(&b.date))
+        });
+        Self { accounts, entries }
+    }
+
+    pub fn visible_accounts(&self, show_archived: bool) -> Vec<&InvestmentAccount> {
+        self.accounts
+            .iter()
+            .filter(|account| show_archived || !account.archived)
+            .collect()
+    }
+
+    pub fn account(&self, id: i64) -> Option<&InvestmentAccount> {
+        self.accounts.iter().find(|account| account.id == id)
+    }
+
+    pub fn entries_for(&self, account_id: i64) -> impl Iterator<Item = &InvestmentEntry> {
+        self.entries
+            .iter()
+            .filter(move |entry| entry.account_id == account_id)
+    }
+
+    pub fn earliest_date(&self, account_id: Option<i64>, show_archived: bool) -> Option<NaiveDate> {
+        let ids = self.target_ids(account_id, show_archived);
+        self.entries
+            .iter()
+            .filter(|entry| ids.contains(&entry.account_id))
+            .map(|entry| entry.date)
+            .min()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.accounts.is_empty()
+    }
+
+    fn last_valuation(&self, account_id: i64, date: NaiveDate) -> Option<&InvestmentEntry> {
+        self.entries.iter().rfind(|entry| {
+            entry.account_id == account_id
+                && entry.entry_kind == InvestmentEntryKind::Valuation
+                && entry.date <= date
+        })
+    }
+
+    pub fn last_valuation_date(&self, account_id: i64) -> Option<NaiveDate> {
+        self.entries
+            .iter()
+            .rfind(|entry| {
+                entry.account_id == account_id && entry.entry_kind == InvestmentEntryKind::Valuation
+            })
+            .map(|entry| entry.date)
+    }
+
+    /// `after` is exclusive so a flow never lands in two adjacent periods.
+    fn net_flow(&self, account_id: i64, after: Option<NaiveDate>, through: NaiveDate) -> Decimal {
+        self.entries
+            .iter()
+            .filter(|entry| entry.account_id == account_id && entry.date <= through)
+            .filter(|entry| after.is_none_or(|bound| entry.date > bound))
+            .map(|entry| entry.amount * entry.entry_kind.flow_sign())
+            .sum()
+    }
+
+    /// Valuations read as end of day, so a same-day contribution is already inside one.
+    /// That's what stops it counting twice or looking like growth.
+    pub fn value_on(&self, account_id: i64, date: NaiveDate) -> Decimal {
+        match self.last_valuation(account_id, date) {
+            Some(mark) => mark.amount + self.net_flow(account_id, Some(mark.date), date),
+            None => self.net_flow(account_id, None, date),
+        }
+    }
+
+    pub fn position(&self, account_id: i64, on: NaiveDate) -> InvestmentPosition {
+        InvestmentPosition {
+            value: self.value_on(account_id, on),
+            invested: self.net_flow(account_id, None, on),
+            as_of: self.last_valuation_date(account_id),
+        }
+    }
+
+    /// Oldest mark wins: a total is only as current as its stalest part.
+    pub fn total_position(&self, on: NaiveDate, show_archived: bool) -> InvestmentPosition {
+        let accounts = self.visible_accounts(show_archived);
+        InvestmentPosition {
+            value: accounts
+                .iter()
+                .map(|account| self.value_on(account.id, on))
+                .sum(),
+            invested: accounts
+                .iter()
+                .map(|account| self.net_flow(account.id, None, on))
+                .sum(),
+            as_of: accounts
+                .iter()
+                .filter_map(|account| self.last_valuation_date(account.id))
+                .min(),
+        }
+    }
+
+    fn first_entry(&self, account_id: i64) -> Option<NaiveDate> {
+        self.entries
+            .iter()
+            .find(|entry| entry.account_id == account_id)
+            .map(|entry| entry.date)
+    }
+
+    /// An account counts only from its own first entry, never from before you tracked it.
+    fn effective_start(&self, account_id: i64, start: NaiveDate) -> NaiveDate {
+        match self.first_entry(account_id) {
+            Some(first) => start.max(first),
+            None => start,
+        }
+    }
+
+    fn window_starts(
+        &self,
+        account_id: Option<i64>,
+        start: NaiveDate,
+        show_archived: bool,
+    ) -> Vec<(i64, NaiveDate)> {
+        self.target_ids(account_id, show_archived)
+            .into_iter()
+            .map(|id| (id, self.effective_start(id, start)))
+            .collect()
+    }
+
+    pub fn gain_between(
+        &self,
+        account_id: Option<i64>,
+        start: NaiveDate,
+        end: NaiveDate,
+        show_archived: bool,
+    ) -> Decimal {
+        self.window_starts(account_id, start, show_archived)
+            .into_iter()
+            .map(|(id, from)| {
+                self.value_on(id, end)
+                    - self.value_on(id, from)
+                    - self.net_flow(id, Some(from), end)
+            })
+            .sum()
+    }
+
+    pub fn invested_between(
+        &self,
+        account_id: Option<i64>,
+        start: NaiveDate,
+        end: NaiveDate,
+        show_archived: bool,
+    ) -> Decimal {
+        self.window_starts(account_id, start, show_archived)
+            .into_iter()
+            .map(|(id, from)| self.net_flow(id, Some(from), end))
+            .sum()
+    }
+
+    fn target_ids(&self, account_id: Option<i64>, show_archived: bool) -> Vec<i64> {
+        match account_id {
+            Some(id) => vec![id],
+            None => self
+                .visible_accounts(show_archived)
+                .iter()
+                .map(|account| account.id)
+                .collect(),
+        }
+    }
+
+    /// Weights each flow by how long it was actually invested.
+    pub fn modified_dietz(
+        &self,
+        account_id: Option<i64>,
+        start: NaiveDate,
+        end: NaiveDate,
+        show_archived: bool,
+    ) -> Option<Decimal> {
+        let days = (end - start).num_days();
+        if days <= 0 {
+            return None;
+        }
+
+        let starts = self.window_starts(account_id, start, show_archived);
+        let opening: Decimal = starts
+            .iter()
+            .map(|(id, from)| self.value_on(*id, *from))
+            .sum();
+        let gain = self.gain_between(account_id, start, end, show_archived);
+
+        let weighted: Decimal = self
+            .entries
+            .iter()
+            .filter(|entry| {
+                starts
+                    .iter()
+                    .any(|(id, from)| *id == entry.account_id && entry.date > *from)
+            })
+            .filter(|entry| entry.date <= end)
+            .map(|entry| {
+                let remaining = (end - entry.date).num_days();
+                let weight = Decimal::from(remaining) / Decimal::from(days);
+                entry.amount * entry.entry_kind.flow_sign() * weight
+            })
+            .sum();
+
+        let base = opening + weighted;
+        (base > Decimal::ZERO).then(|| (gain / base) * Decimal::from(100))
+    }
+
+    pub fn annualized_return(
+        &self,
+        account_id: Option<i64>,
+        start: NaiveDate,
+        end: NaiveDate,
+        show_archived: bool,
+    ) -> Option<f64> {
+        let years = (end - start).num_days() as f64 / 365.25;
+        if years <= 0.0 {
+            return None;
+        }
+
+        // Periods butt up at each year end, or a move on Jan 1 falls through the gap.
+        let mut compounded = 1.0f64;
+        let mut measured = false;
+        let mut period_start = start;
+        for year in start.year()..=end.year() {
+            let period_end = NaiveDate::from_ymd_opt(year, 12, 31)
+                .unwrap_or(end)
+                .min(end);
+            if period_end <= period_start {
+                continue;
+            }
+            if let Some(period) =
+                self.modified_dietz(account_id, period_start, period_end, show_archived)
+            {
+                compounded *= 1.0 + (period.to_f64().unwrap_or(0.0) / 100.0);
+                measured = true;
+            }
+            period_start = period_end;
+        }
+
+        // Zero is a real wipeout that both formulas below report as -100%.
+        if !measured || compounded < 0.0 {
+            return None;
+        }
+        // Annualizing a few weeks out to a year reads as a wild claim.
+        if years < 1.0 {
+            return Some((compounded - 1.0) * 100.0);
+        }
+        Some((compounded.powf(1.0 / years) - 1.0) * 100.0)
+    }
+
+    pub fn series(
+        &self,
+        start: NaiveDate,
+        end: NaiveDate,
+        points: usize,
+        account_id: Option<i64>,
+        show_archived: bool,
+    ) -> Vec<(NaiveDate, Decimal, Decimal)> {
+        let points = points.max(2);
+        let span = (end - start).num_days().max(1);
+        let ids = self.target_ids(account_id, show_archived);
+
+        (0..points)
+            .map(|step| {
+                let offset = span * step as i64 / (points as i64 - 1);
+                let date = start + Duration::days(offset);
+                let value = ids.iter().map(|id| self.value_on(*id, date)).sum();
+                let invested = ids.iter().map(|id| self.net_flow(*id, None, date)).sum();
+                (date, value, invested)
+            })
+            .collect()
+    }
+
+    pub fn yearly_breakdown(
+        &self,
+        account_id: Option<i64>,
+        show_archived: bool,
+    ) -> Vec<(i32, Decimal, Decimal, Option<Decimal>)> {
+        let ids = self.target_ids(account_id, show_archived);
+        let Some(first) = self
+            .entries
+            .iter()
+            .filter(|entry| ids.contains(&entry.account_id))
+            .map(|entry| entry.date)
+            .min()
+        else {
+            return Vec::new();
+        };
+        let today = chrono::Local::now().date_naive();
+
+        (first.year()..=today.year())
+            .map(|year| {
+                // First year opens at the first entry, or pre-tracking growth lands in it.
+                let start = NaiveDate::from_ymd_opt(year - 1, 12, 31)
+                    .unwrap_or(first)
+                    .max(first);
+                let end = NaiveDate::from_ymd_opt(year, 12, 31)
+                    .unwrap_or(today)
+                    .min(today);
+                (
+                    year,
+                    self.invested_between(account_id, start, end, show_archived),
+                    self.gain_between(account_id, start, end, show_archived),
+                    self.modified_dietz(account_id, start, end, show_archived),
+                )
+            })
+            .collect()
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -686,13 +686,8 @@ impl Portfolio {
         })
     }
 
-    pub fn last_valuation_date(&self, account_id: i64) -> Option<NaiveDate> {
-        self.entries
-            .iter()
-            .rfind(|entry| {
-                entry.account_id == account_id && entry.entry_kind == InvestmentEntryKind::Valuation
-            })
-            .map(|entry| entry.date)
+    pub fn last_valuation_date(&self, account_id: i64, on: NaiveDate) -> Option<NaiveDate> {
+        self.last_valuation(account_id, on).map(|entry| entry.date)
     }
 
     /// `after` is exclusive so a flow never lands in two adjacent periods.
@@ -718,7 +713,7 @@ impl Portfolio {
         InvestmentPosition {
             value: self.value_on(account_id, on),
             invested: self.net_flow(account_id, None, on),
-            as_of: self.last_valuation_date(account_id),
+            as_of: self.last_valuation_date(account_id, on),
         }
     }
 
@@ -736,7 +731,7 @@ impl Portfolio {
                 .sum(),
             as_of: accounts
                 .iter()
-                .filter_map(|account| self.last_valuation_date(account.id))
+                .filter_map(|account| self.last_valuation_date(account.id, on))
                 .min(),
         }
     }
@@ -749,22 +744,22 @@ impl Portfolio {
     }
 
     /// An account counts only from its own first entry, never from before you tracked it.
-    fn effective_start(&self, account_id: i64, start: NaiveDate) -> NaiveDate {
-        match self.first_entry(account_id) {
-            Some(first) => start.max(first),
-            None => start,
-        }
-    }
-
+    /// Each account paired with the date it starts counting from. Accounts that had no
+    /// entries yet are dropped, or subtracting their later opening value invents a loss in
+    /// a period before they existed.
     fn window_starts(
         &self,
         account_id: Option<i64>,
         start: NaiveDate,
+        end: NaiveDate,
         show_archived: bool,
     ) -> Vec<(i64, NaiveDate)> {
         self.target_ids(account_id, show_archived)
             .into_iter()
-            .map(|id| (id, self.effective_start(id, start)))
+            .filter_map(|id| {
+                let first = self.first_entry(id)?;
+                (first <= end).then_some((id, start.max(first)))
+            })
             .collect()
     }
 
@@ -775,7 +770,7 @@ impl Portfolio {
         end: NaiveDate,
         show_archived: bool,
     ) -> Decimal {
-        self.window_starts(account_id, start, show_archived)
+        self.window_starts(account_id, start, end, show_archived)
             .into_iter()
             .map(|(id, from)| {
                 self.value_on(id, end)
@@ -822,12 +817,20 @@ impl Portfolio {
             return None;
         }
 
-        let starts = self.window_starts(account_id, start, show_archived);
+        let starts = self.window_starts(account_id, start, end, show_archived);
+        let gain = self.gain_between(account_id, start, end, show_archived);
+        let weight = |date: NaiveDate| Decimal::from((end - date).num_days()) / Decimal::from(days);
         let opening: Decimal = starts
             .iter()
-            .map(|(id, from)| self.value_on(*id, *from))
+            .map(|(id, from)| {
+                let value = self.value_on(*id, *from);
+                if *from > start {
+                    value * weight(*from)
+                } else {
+                    value
+                }
+            })
             .sum();
-        let gain = self.gain_between(account_id, start, end, show_archived);
 
         let weighted: Decimal = self
             .entries
@@ -838,11 +841,7 @@ impl Portfolio {
                     .any(|(id, from)| *id == entry.account_id && entry.date > *from)
             })
             .filter(|entry| entry.date <= end)
-            .map(|entry| {
-                let remaining = (end - entry.date).num_days();
-                let weight = Decimal::from(remaining) / Decimal::from(days);
-                entry.amount * entry.entry_kind.flow_sign() * weight
-            })
+            .map(|entry| entry.amount * entry.entry_kind.flow_sign() * weight(entry.date))
             .sum();
 
         let base = opening + weighted;

--- a/src/model.rs
+++ b/src/model.rs
@@ -792,9 +792,9 @@ impl Portfolio {
         end: NaiveDate,
         show_archived: bool,
     ) -> Decimal {
-        self.window_starts(account_id, start, show_archived)
+        self.target_ids(account_id, show_archived)
             .into_iter()
-            .map(|(id, from)| self.net_flow(id, Some(from), end))
+            .map(|id| self.net_flow(id, Some(start), end))
             .sum()
     }
 
@@ -934,10 +934,7 @@ impl Portfolio {
 
         (first.year()..=today.year())
             .map(|year| {
-                // First year opens at the first entry, or pre-tracking growth lands in it.
-                let start = NaiveDate::from_ymd_opt(year - 1, 12, 31)
-                    .unwrap_or(first)
-                    .max(first);
+                let start = NaiveDate::from_ymd_opt(year - 1, 12, 31).unwrap_or(first);
                 let end = NaiveDate::from_ymd_opt(year, 12, 31)
                     .unwrap_or(today)
                     .min(today);

--- a/src/ui/budget.rs
+++ b/src/ui/budget.rs
@@ -1,6 +1,6 @@
 use crate::app::state::{App, BudgetCategoryComparison, BudgetEditTarget};
 use crate::model::{BudgetEditScope, BudgetMonth};
-use crate::ui::helpers::{format_amount, month_to_color, month_to_short_str};
+use crate::ui::helpers::{format_amount, format_signed_amount, month_to_color, month_to_short_str};
 use ratatui::prelude::*;
 use ratatui::text::Line;
 use ratatui::widgets::{
@@ -19,14 +19,6 @@ fn budget_panel_block(title: Line<'static>, borders: Borders) -> Block<'static> 
         .title(title)
         .borders(borders)
         .border_style(Style::default().fg(PANEL_CHROME_COLOR))
-}
-
-fn format_budget_variance(variance: Decimal) -> String {
-    if variance >= Decimal::ZERO {
-        format!("+{}", format_amount(&variance))
-    } else {
-        format_amount(&variance)
-    }
 }
 
 fn usage_color(actual: Decimal, target: Decimal) -> Color {
@@ -94,7 +86,7 @@ fn comparison_row(comparison: &BudgetCategoryComparison) -> Row<'static> {
             Line::from(format_amount(&comparison.actual_expense)).alignment(Alignment::Right),
         )
         .style(spent_style),
-        Cell::from(Line::from(format_budget_variance(remaining)).alignment(Alignment::Right))
+        Cell::from(Line::from(format_signed_amount(&remaining)).alignment(Alignment::Right))
             .style(remaining_style),
         Cell::from(
             Line::from(usage_percent(comparison.actual_expense, comparison.budget))
@@ -416,7 +408,7 @@ pub fn render_budget_view(f: &mut Frame, app: &mut App, area: Rect) {
         Span::styled("Spare:  ", Style::default().add_modifier(Modifier::BOLD)),
         Span::styled(
             match unallocated_budget {
-                Some(value) => format_budget_variance(value),
+                Some(value) => format_signed_amount(&value),
                 None => "N/A".to_string(),
             },
             match unallocated_budget {
@@ -484,7 +476,7 @@ pub fn render_budget_view(f: &mut Frame, app: &mut App, area: Rect) {
             Span::styled("Left:   ", Style::default().add_modifier(Modifier::BOLD)),
             Span::styled(
                 match remaining_budget {
-                    Some(value) => format_budget_variance(value),
+                    Some(value) => format_signed_amount(&value),
                     None => "N/A".to_string(),
                 },
                 match remaining_budget {
@@ -707,7 +699,7 @@ pub fn render_budget_view(f: &mut Frame, app: &mut App, area: Rect) {
             Line::from(vec![
                 Span::styled("Left:     ", Style::default().add_modifier(Modifier::BOLD)),
                 Span::styled(
-                    format_budget_variance(remaining),
+                    format_signed_amount(&remaining),
                     if remaining < Decimal::ZERO {
                         Style::default().fg(Color::LightRed)
                     } else {

--- a/src/ui/category_manager.rs
+++ b/src/ui/category_manager.rs
@@ -1,6 +1,7 @@
-use crate::app::fields::{CategoryEditField, FieldKey, FieldKind};
+use crate::app::fields::CategoryEditField;
 use crate::app::state::App;
 use crate::model::{CategorySortColumn, SortOrder};
+use crate::ui::form::render_field_form;
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 
@@ -132,98 +133,24 @@ pub fn render_category_filter_input(f: &mut Frame, app: &App, area: Rect) {
 pub fn render_category_editor(f: &mut Frame, app: &App, area: Rect) {
     let income_category =
         app.category_edit_fields[CategoryEditField::TransactionType].eq_ignore_ascii_case("income");
-    let focused_field = app.category_edit_fields.focused();
-    let input_widgets: Vec<_> = app
-        .category_edit_fields
-        .iter()
-        .map(|(field, text)| {
-            let is_focused = field == focused_field;
-            let title = format!("{} {}", field.label(), field.hint())
-                .trim_end()
-                .to_string();
-            let content = if field.kind() == FieldKind::Toggle {
-                Span::styled(
-                    format!(" < {} > ", text),
-                    Style::default().fg(Color::White).bold(),
-                )
-            } else if field == CategoryEditField::Budget && income_category {
-                Span::styled(
-                    "Expense categories only",
-                    Style::default().fg(Color::DarkGray),
-                )
-            } else {
-                Span::raw(text.as_str())
-            };
-
-            Paragraph::new(content).block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .title(title)
-                    .border_style(if is_focused {
-                        Style::default().fg(Color::Yellow)
-                    } else {
-                        Style::default()
-                    }),
-            )
-        })
-        .collect();
-
-    let margin = 1;
-    let field_height = 3;
-    let total_fields = input_widgets.len();
-    let available_height = area.height.saturating_sub(margin * 2);
-    let max_visible_fields = ((available_height / field_height) as usize)
-        .max(1)
-        .min(total_fields);
-    let scroll_offset = focused_field
-        .index()
-        .saturating_sub(max_visible_fields - 1)
-        .min(total_fields - max_visible_fields);
-
-    let mut constraints = Vec::with_capacity(max_visible_fields + 1);
-    for _ in 0..max_visible_fields {
-        constraints.push(Constraint::Length(field_height));
-    }
-    constraints.push(Constraint::Min(0));
-
-    let form_chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .margin(margin)
-        .constraints(constraints)
-        .split(area);
-
-    for (index, widget) in input_widgets
-        .iter()
-        .enumerate()
-        .skip(scroll_offset)
-        .take(max_visible_fields)
-    {
-        let chunk_index = index - scroll_offset;
-        f.render_widget(widget.clone(), form_chunks[chunk_index]);
-    }
-
-    let form_title = if app.editing_category_id.is_some() {
+    let title = if app.editing_category_id.is_some() {
         "Edit Category"
     } else {
         "Add Category"
     };
-    let form_block = Block::default()
-        .title(form_title)
-        .title_bottom(" [Esc] Cancel, [Enter] Toggle/Save ")
-        .borders(Borders::ALL);
-    f.render_widget(form_block, area);
 
-    if focused_field.kind().is_editable() {
-        let field_idx = focused_field.index();
-        let text = &app.category_edit_fields[focused_field];
-        let cursor_byte_idx = app.category_edit_cursor.min(text.len());
-        let visual_cursor = text[..cursor_byte_idx].chars().count() as u16;
-
-        if field_idx >= scroll_offset && field_idx < scroll_offset + max_visible_fields {
-            let visible_idx = field_idx - scroll_offset;
-            if let Some(chunk) = form_chunks.get(visible_idx) {
-                f.set_cursor_position(Position::new(chunk.x + visual_cursor + 1, chunk.y + 1));
-            }
-        }
-    }
+    render_field_form(
+        f,
+        &app.category_edit_fields,
+        app.category_edit_cursor,
+        area,
+        title,
+        Some(" [Esc] Cancel, [Enter] Toggle/Save "),
+        // Budgets are keyed on expense categories, so there is nothing to set here.
+        if income_category {
+            |field| (field == CategoryEditField::Budget).then_some("Expense categories only")
+        } else {
+            |_| None
+        },
+    );
 }

--- a/src/ui/form.rs
+++ b/src/ui/form.rs
@@ -1,0 +1,102 @@
+use crate::app::fields::{FieldKey, FieldKind, FieldSet};
+use ratatui::prelude::*;
+use ratatui::widgets::*;
+
+/// A field that doesn't apply right now, dimmed in place of its value.
+pub type Placeholder<K> = fn(K) -> Option<&'static str>;
+
+pub fn render_field_form<K: FieldKey, const N: usize>(
+    f: &mut Frame,
+    fields: &FieldSet<K, N>,
+    cursor: usize,
+    area: Rect,
+    title: &str,
+    bottom_hint: Option<&str>,
+    placeholder: Placeholder<K>,
+) {
+    let focused_field = fields.focused();
+    let input_widgets: Vec<_> = fields
+        .iter()
+        .map(|(field, text)| {
+            let box_title = format!("{} {}", field.label(), field.hint())
+                .trim_end()
+                .to_string();
+            let content = match placeholder(field) {
+                Some(hint) => Span::styled(hint, Style::default().fg(Color::DarkGray)),
+                None if field.kind() == FieldKind::Toggle => Span::styled(
+                    format!(" < {} > ", text),
+                    Style::default().fg(Color::White).bold(),
+                ),
+                None => Span::raw(text.as_str()),
+            };
+
+            Paragraph::new(content)
+                .style(Style::default().fg(Color::White))
+                .block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title(box_title)
+                        .border_style(if field == focused_field {
+                            Style::default().fg(Color::Yellow)
+                        } else {
+                            Style::default()
+                        }),
+                )
+        })
+        .collect();
+
+    let margin = 1;
+    let field_height = 3;
+    let total_fields = input_widgets.len();
+    let available_height = area.height.saturating_sub(margin * 2);
+    let max_visible_fields = ((available_height / field_height) as usize)
+        .max(1)
+        .min(total_fields);
+    let scroll_offset = focused_field
+        .index()
+        .saturating_sub(max_visible_fields - 1)
+        .min(total_fields - max_visible_fields);
+
+    let mut constraints = Vec::with_capacity(max_visible_fields + 1);
+    for _ in 0..max_visible_fields {
+        constraints.push(Constraint::Length(field_height));
+    }
+    constraints.push(Constraint::Min(0));
+
+    let form_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(margin)
+        .constraints(constraints)
+        .split(area);
+
+    for (index, widget) in input_widgets
+        .iter()
+        .enumerate()
+        .skip(scroll_offset)
+        .take(max_visible_fields)
+    {
+        f.render_widget(widget.clone(), form_chunks[index - scroll_offset]);
+    }
+
+    let mut form_block = Block::default()
+        .title(title.to_string())
+        .borders(Borders::ALL);
+    if let Some(hint) = bottom_hint {
+        form_block = form_block.title_bottom(hint.to_string());
+    }
+    f.render_widget(form_block, area);
+
+    if focused_field.kind().is_editable() && placeholder(focused_field).is_none() {
+        let field_index = focused_field.index();
+        let text = &fields[focused_field];
+        let cursor_byte_idx = cursor.min(text.len());
+        let visual_cursor = text[..cursor_byte_idx].chars().count() as u16;
+
+        if field_index >= scroll_offset
+            && field_index < scroll_offset + max_visible_fields
+            && let Some(chunk) = form_chunks.get(field_index - scroll_offset)
+        {
+            f.set_cursor_position(Position::new(chunk.x + visual_cursor + 1, chunk.y + 1));
+        }
+    }
+}

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -63,6 +63,13 @@ pub fn render_help_bar(f: &mut Frame, app: &App, area: Rect) {
             ),
             Span::raw(" Budg | "),
             Span::styled(
+                "i",
+                Style::default()
+                    .fg(Color::LightCyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" Inv | "),
+            Span::styled(
                 "1-6",
                 Style::default()
                     .fg(Color::LightBlue)
@@ -291,6 +298,52 @@ pub fn render_help_bar(f: &mut Frame, app: &App, area: Rect) {
             Span::raw(": Cancel"),
         ],
         AppMode::ConfirmCategoryDelete => vec![
+            Span::styled("y", Style::default().fg(Color::LightGreen)),
+            Span::raw(": Confirm | "),
+            Span::styled("n/Esc", Style::default().fg(Color::LightRed)),
+            Span::raw(": Cancel"),
+        ],
+        AppMode::Investments => vec![
+            Span::raw("↑↓ Nav | "),
+            Span::styled("←→", Style::default().fg(Color::Magenta)),
+            Span::raw(" Range | "),
+            Span::styled("Enter", Style::default().fg(Color::LightCyan)),
+            Span::raw(" Detail | "),
+            Span::styled("v", Style::default().fg(Color::LightCyan)),
+            Span::raw(" Value | "),
+            Span::styled("a", Style::default().fg(Color::LightGreen)),
+            Span::raw(" Add | "),
+            Span::styled("e", Style::default().fg(Color::LightYellow)),
+            Span::raw(" Edit | "),
+            Span::styled("d", Style::default().fg(Color::LightRed)),
+            Span::raw(" Del | "),
+            Span::styled("q/Esc", Style::default().fg(Color::Magenta)),
+            Span::raw(" Back"),
+        ],
+        AppMode::InvestmentDetail => vec![
+            Span::raw("↑↓ Entries | "),
+            Span::styled("←→", Style::default().fg(Color::Magenta)),
+            Span::raw(" Range | "),
+            Span::styled("v", Style::default().fg(Color::LightCyan)),
+            Span::raw(" Value | "),
+            Span::styled("a", Style::default().fg(Color::LightGreen)),
+            Span::raw(" Add | "),
+            Span::styled("e/Enter", Style::default().fg(Color::LightYellow)),
+            Span::raw(" Edit | "),
+            Span::styled("d", Style::default().fg(Color::LightRed)),
+            Span::raw(" Del | "),
+            Span::styled("q/Esc", Style::default().fg(Color::Magenta)),
+            Span::raw(" Back"),
+        ],
+        AppMode::InvestmentAccountEditor | AppMode::InvestmentEntryEditor => vec![
+            Span::raw("Tab/↑↓ Nav | "),
+            Span::raw("←→ Adjust | "),
+            Span::styled("Enter", Style::default().fg(Color::LightGreen)),
+            Span::raw(" Toggle/Save | "),
+            Span::styled("Esc", Style::default().fg(Color::LightRed)),
+            Span::raw(" Cancel"),
+        ],
+        AppMode::ConfirmInvestmentDelete => vec![
             Span::styled("y", Style::default().fg(Color::LightGreen)),
             Span::raw(": Confirm | "),
             Span::styled("n/Esc", Style::default().fg(Color::LightRed)),

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -27,6 +27,15 @@ pub fn format_amount(amount: &Decimal) -> String {
     format!("{}{}.{}", sign, formatted_int, frac_part)
 }
 
+/// Signed for display, so a gain or a variance reads as one at a glance.
+pub fn format_signed_amount(amount: &Decimal) -> String {
+    if amount >= &Decimal::ZERO {
+        format!("+{}", format_amount(amount))
+    } else {
+        format_amount(amount)
+    }
+}
+
 pub fn format_hours(amount: &Decimal, hourly_rate: Option<Decimal>) -> String {
     if let Some(rate) = hourly_rate
         && rate > Decimal::ZERO

--- a/src/ui/investments.rs
+++ b/src/ui/investments.rs
@@ -1,0 +1,670 @@
+use crate::app::investments::STALE_VALUATION_DAYS;
+use crate::app::state::App;
+use crate::model::{InvestmentEntryKind, InvestmentRange};
+use crate::ui::form::render_field_form;
+use crate::ui::helpers::{centered_rect, format_amount, format_signed_amount};
+use chrono::NaiveDate;
+use ratatui::prelude::*;
+use ratatui::widgets::{
+    Axis, Block, Borders, Cell, Chart, Clear, Dataset, GraphType, Paragraph, Row, Table, Wrap,
+};
+use rust_decimal::Decimal;
+use rust_decimal::prelude::ToPrimitive;
+
+const PANEL_CHROME_COLOR: Color = Color::LightBlue;
+const VALUE_COLOR: Color = Color::LightCyan;
+const INVESTED_COLOR: Color = Color::Magenta;
+const STALE_COLOR: Color = Color::Rgb(255, 165, 0);
+
+fn panel(title: Line<'static>, borders: Borders) -> Block<'static> {
+    Block::default()
+        .title(title)
+        .borders(borders)
+        .border_style(Style::default().fg(PANEL_CHROME_COLOR))
+}
+
+fn heading(text: &str) -> Span<'static> {
+    Span::styled(
+        text.to_string(),
+        Style::default()
+            .fg(PANEL_CHROME_COLOR)
+            .add_modifier(Modifier::BOLD),
+    )
+}
+
+fn gain_style(amount: Decimal) -> Style {
+    if amount < Decimal::ZERO {
+        Style::default().fg(Color::LightRed)
+    } else {
+        Style::default().fg(Color::LightGreen)
+    }
+}
+
+fn format_percent(value: Option<Decimal>) -> String {
+    match value {
+        Some(percent) => format!(
+            "{}{:.1}%",
+            if percent >= Decimal::ZERO { "+" } else { "" },
+            percent.to_f64().unwrap_or(0.0)
+        ),
+        None => "N/A".to_string(),
+    }
+}
+
+fn format_rate(value: Option<f64>) -> String {
+    match value {
+        Some(percent) => format!("{}{:.1}%", if percent >= 0.0 { "+" } else { "" }, percent),
+        None => "N/A".to_string(),
+    }
+}
+
+pub fn render_investments_view(f: &mut Frame, app: &mut App, area: Rect) {
+    if app.portfolio.is_empty() {
+        render_empty_state(f, area);
+        return;
+    }
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(6),
+            Constraint::Length(accounts_table_height(app)),
+        ])
+        .split(area);
+
+    render_stats_panel(f, app, chunks[0]);
+    render_value_chart(f, app, chunks[1]);
+    render_accounts_table(f, app, chunks[2]);
+}
+
+pub fn render_investment_detail(f: &mut Frame, app: &mut App, area: Rect) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(6),
+            Constraint::Percentage(45),
+        ])
+        .split(area);
+
+    render_stats_panel(f, app, chunks[0]);
+    render_value_chart(f, app, chunks[1]);
+
+    let bottom = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(58), Constraint::Percentage(42)])
+        .split(chunks[2]);
+
+    render_entries_table(f, app, bottom[0]);
+    render_yearly_table(f, app, bottom[1]);
+}
+
+fn accounts_table_height(app: &App) -> u16 {
+    // rule, header, spacer, totals
+    let rows = app.visible_investment_ids().len() as u16 + 4;
+    rows.clamp(5, 14)
+}
+
+fn render_empty_state(f: &mut Frame, area: Rect) {
+    let body = Paragraph::new(vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "No investment accounts yet.",
+            Style::default().add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from("Press 'a' to add one. You can give it a starting value and how much of"),
+        Line::from("that you contributed, so growth is measured from the right place."),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Then record a valuation ('v') whenever you check on it, and a contribution",
+            Style::default().fg(Color::DarkGray),
+        )),
+        Line::from(Span::styled(
+            "or withdrawal ('n') whenever money moves. Growth is worked out from those.",
+            Style::default().fg(Color::DarkGray),
+        )),
+    ])
+    .alignment(Alignment::Center)
+    .wrap(Wrap { trim: true })
+    .block(panel(Line::from(heading("Investments")), Borders::TOP));
+
+    f.render_widget(body, area);
+}
+
+fn render_stats_panel(f: &mut Frame, app: &App, area: Rect) {
+    let position = app.investment_position();
+    let (start, end) = app.investment_window();
+    let account_id = app.investment_detail_id;
+    let archived = app.show_archived_investments;
+
+    let period_gain = app.portfolio.gain_between(account_id, start, end, archived);
+    let annualized = app
+        .portfolio
+        .annualized_return(account_id, start, end, archived);
+
+    let title = match account_id.and_then(|id| app.portfolio.account(id)) {
+        Some(account) => {
+            let mut spans = vec![heading(&account.name)];
+            if !account.kind.trim().is_empty() {
+                spans.push(Span::styled(" | ", Style::default().fg(PANEL_CHROME_COLOR)));
+                spans.push(Span::styled(
+                    account.kind.clone(),
+                    Style::default().fg(Color::Cyan),
+                ));
+            }
+            if account.archived {
+                spans.push(Span::styled(
+                    " (archived)",
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
+            Line::from(spans)
+        }
+        None => Line::from(vec![
+            heading("Investments"),
+            Span::styled(" | ", Style::default().fg(PANEL_CHROME_COLOR)),
+            Span::styled(
+                app.active_ledger_name().to_string(),
+                Style::default().fg(Color::Cyan),
+            ),
+        ]),
+    };
+
+    let block = panel(title, Borders::TOP);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let columns = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(34),
+            Constraint::Percentage(33),
+            Constraint::Percentage(33),
+        ])
+        .split(inner);
+
+    let value_lines = vec![
+        stat_line(
+            "Value",
+            format_amount(&position.value),
+            Style::default().fg(VALUE_COLOR),
+        ),
+        stat_line(
+            "Invested",
+            format_amount(&position.invested),
+            Style::default().fg(INVESTED_COLOR),
+        ),
+    ];
+    let gain_lines = vec![
+        stat_line(
+            "Gain",
+            format_signed_amount(&position.gain()),
+            gain_style(position.gain()),
+        ),
+        stat_line(
+            "ROI",
+            format_percent(position.roi()),
+            gain_style(position.gain()),
+        ),
+    ];
+    // Over All this would contradict Gain, so show freshness instead.
+    let period_lines = vec![
+        match app.investment_range {
+            InvestmentRange::All => stat_line(
+                "As of",
+                position
+                    .as_of
+                    .map(|date| date.format("%Y-%m-%d").to_string())
+                    .unwrap_or_else(|| "-".to_string()),
+                Style::default().fg(Color::DarkGray),
+            ),
+            range => stat_line(
+                range.label(),
+                format_signed_amount(&period_gain),
+                gain_style(period_gain),
+            ),
+        },
+        stat_line(
+            "Annual",
+            format_rate(annualized),
+            Style::default().fg(Color::White),
+        ),
+    ];
+
+    f.render_widget(Paragraph::new(value_lines), columns[0]);
+    f.render_widget(Paragraph::new(gain_lines), columns[1]);
+    f.render_widget(Paragraph::new(period_lines), columns[2]);
+}
+
+fn stat_line(label: &str, value: String, style: Style) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("{:<9}", label),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(value, style),
+    ])
+}
+
+/// The gap between the two lines is the growth.
+fn render_value_chart(f: &mut Frame, app: &App, area: Rect) {
+    let (start, end) = app.investment_window();
+    let points = (area.width.saturating_sub(12)).max(2) as usize;
+    let series = app.portfolio.series(
+        start,
+        end,
+        points,
+        app.investment_detail_id,
+        app.show_archived_investments,
+    );
+
+    let value_points: Vec<(f64, f64)> = series
+        .iter()
+        .enumerate()
+        .map(|(index, (_, value, _))| (index as f64, value.to_f64().unwrap_or(0.0)))
+        .collect();
+    let invested_points: Vec<(f64, f64)> = series
+        .iter()
+        .enumerate()
+        .map(|(index, (_, _, invested))| (index as f64, invested.to_f64().unwrap_or(0.0)))
+        .collect();
+
+    let peak = value_points
+        .iter()
+        .chain(invested_points.iter())
+        .map(|(_, y)| *y)
+        .fold(0.0f64, f64::max);
+    let y_max = if peak <= 0.0 { 1.0 } else { peak * 1.1 };
+    let x_max = (series.len().max(2) - 1) as f64;
+
+    let datasets = vec![
+        Dataset::default()
+            .name("Invested")
+            .marker(symbols::Marker::Braille)
+            .graph_type(GraphType::Line)
+            .style(Style::default().fg(INVESTED_COLOR))
+            .data(&invested_points),
+        Dataset::default()
+            .name("Value")
+            .marker(symbols::Marker::Braille)
+            .graph_type(GraphType::Line)
+            .style(Style::default().fg(VALUE_COLOR))
+            .data(&value_points),
+    ];
+
+    let title = Line::from(vec![
+        heading("Growth"),
+        Span::styled(" | ", Style::default().fg(PANEL_CHROME_COLOR)),
+        Span::styled(
+            app.investment_range.label().to_string(),
+            Style::default()
+                .fg(Color::Magenta)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" (◀/▶) ", Style::default().fg(Color::DarkGray)),
+    ]);
+
+    let chart = Chart::new(datasets)
+        .block(panel(title, Borders::TOP))
+        .x_axis(
+            Axis::default()
+                .bounds([0.0, x_max])
+                .labels(axis_dates(start, end)),
+        )
+        .y_axis(
+            Axis::default()
+                .bounds([0.0, y_max])
+                .labels(axis_amounts(y_max)),
+        );
+
+    f.render_widget(chart, area);
+}
+
+fn axis_dates(start: NaiveDate, end: NaiveDate) -> Vec<Span<'static>> {
+    let span = (end - start).num_days();
+    // Three labels all reading "Sep 2026" is worse than no labels at all.
+    let format = match span {
+        0..=92 => "%d %b",
+        93..=730 => "%b %Y",
+        _ => "%Y",
+    };
+    let label = |date: NaiveDate| Span::raw(date.format(format).to_string());
+    if span == 0 {
+        return vec![label(end)];
+    }
+    vec![label(start), label(start + (end - start) / 2), label(end)]
+}
+
+fn axis_amounts(y_max: f64) -> Vec<Span<'static>> {
+    [0.0, y_max * 0.5, y_max]
+        .iter()
+        .map(|value| Span::raw(compact_amount(*value)))
+        .collect()
+}
+
+fn compact_amount(value: f64) -> String {
+    match value.abs() {
+        v if v >= 1_000_000.0 => format!("{:.1}M", value / 1_000_000.0),
+        v if v >= 1_000.0 => format!("{:.0}k", value / 1_000.0),
+        _ => format!("{:.0}", value),
+    }
+}
+
+fn render_accounts_table(f: &mut Frame, app: &mut App, area: Rect) {
+    let today = app.today();
+    let archived = app.show_archived_investments;
+    let show_kind = area.width >= 88;
+    let stale_ids: Vec<i64> = app
+        .visible_investment_ids()
+        .into_iter()
+        .filter(|id| app.is_valuation_stale(*id))
+        .collect();
+
+    let mut rows: Vec<Row> = app
+        .portfolio
+        .visible_accounts(archived)
+        .iter()
+        .map(|account| {
+            let position = app.portfolio.position(account.id, today);
+            let stale = stale_ids.contains(&account.id);
+
+            let (as_of_text, as_of_style) = match position.as_of {
+                Some(date) if stale => (
+                    format!("{} !", date.format("%Y-%m-%d")),
+                    Style::default().fg(STALE_COLOR),
+                ),
+                Some(date) => (
+                    date.format("%Y-%m-%d").to_string(),
+                    Style::default().fg(Color::DarkGray),
+                ),
+                None => (
+                    "no value yet".to_string(),
+                    Style::default().fg(Color::DarkGray),
+                ),
+            };
+
+            let name = if show_kind || account.kind.trim().is_empty() {
+                account.name.clone()
+            } else {
+                format!("{} ({})", account.name, account.kind.trim())
+            };
+            let name_style = if account.archived {
+                Style::default().fg(Color::DarkGray)
+            } else {
+                Style::default()
+            };
+
+            let mut cells = vec![Cell::from(name).style(name_style)];
+            if show_kind {
+                cells
+                    .push(Cell::from(account.kind.clone()).style(Style::default().fg(Color::Cyan)));
+            }
+            cells.extend([
+                Cell::from(right(format_amount(&position.value)))
+                    .style(Style::default().fg(VALUE_COLOR)),
+                Cell::from(as_of_text).style(as_of_style),
+                Cell::from(right(format_amount(&position.invested)))
+                    .style(Style::default().fg(INVESTED_COLOR)),
+                Cell::from(right(format_signed_amount(&position.gain())))
+                    .style(gain_style(position.gain())),
+                Cell::from(right(format_percent(position.roi())))
+                    .style(gain_style(position.gain())),
+            ]);
+            Row::new(cells)
+        })
+        .collect();
+
+    let total = app.portfolio.total_position(today, archived);
+    let mut total_cells =
+        vec![Cell::from("Total").style(Style::default().add_modifier(Modifier::BOLD))];
+    if show_kind {
+        total_cells.push(Cell::from(""));
+    }
+    total_cells.extend([
+        Cell::from(right(format_amount(&total.value))).style(
+            Style::default()
+                .fg(VALUE_COLOR)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Cell::from(""),
+        Cell::from(right(format_amount(&total.invested)))
+            .style(Style::default().fg(INVESTED_COLOR)),
+        Cell::from(right(format_signed_amount(&total.gain())))
+            .style(gain_style(total.gain()).add_modifier(Modifier::BOLD)),
+        Cell::from(right(format_percent(total.roi()))).style(gain_style(total.gain())),
+    ]);
+    // Spacer without a row to navigate past.
+    rows.push(Row::new(total_cells).top_margin(1));
+
+    let mut header_cells = vec![Cell::from("Account")];
+    if show_kind {
+        header_cells.push(Cell::from("Type"));
+    }
+    header_cells.extend([
+        Cell::from(right("Value".to_string())),
+        Cell::from("As Of"),
+        Cell::from(right("Invested".to_string())),
+        Cell::from(right("Gain".to_string())),
+        Cell::from(right("ROI".to_string())),
+    ]);
+    let header = Row::new(header_cells).style(
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    );
+
+    let mut widths = vec![Constraint::Min(10)];
+    if show_kind {
+        widths.push(Constraint::Length(12));
+    }
+    widths.extend([
+        Constraint::Length(12),
+        Constraint::Length(12),
+        Constraint::Length(12),
+        Constraint::Length(12),
+        Constraint::Length(7),
+    ]);
+
+    let mut title = vec![heading("Accounts")];
+    if archived {
+        title.push(Span::styled(
+            " (incl. archived)",
+            Style::default().fg(Color::DarkGray),
+        ));
+    } else if app.visible_investment_ids().is_empty() {
+        title.push(Span::styled(
+            " | all archived, press A to show",
+            Style::default().fg(Color::DarkGray),
+        ));
+    }
+    if !stale_ids.is_empty() {
+        title.push(Span::styled(
+            format!(
+                " | {} stale (over {} days)",
+                stale_ids.len(),
+                STALE_VALUATION_DAYS
+            ),
+            Style::default().fg(STALE_COLOR),
+        ));
+    }
+
+    let table = Table::new(rows, widths)
+        .header(header)
+        .block(panel(Line::from(title), Borders::TOP))
+        .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
+        .highlight_symbol("> ");
+
+    f.render_stateful_widget(table, area, &mut app.investment_table_state);
+}
+
+fn render_entries_table(f: &mut Frame, app: &mut App, area: Rect) {
+    let Some(account_id) = app.investment_detail_id else {
+        return;
+    };
+
+    let entries: Vec<_> = {
+        let mut collected: Vec<_> = app.portfolio.entries_for(account_id).collect();
+        collected.reverse();
+        collected
+    };
+
+    let rows: Vec<Row> = entries
+        .iter()
+        .map(|entry| {
+            let (label, style) = match entry.entry_kind {
+                InvestmentEntryKind::Valuation => ("Valuation", Style::default().fg(VALUE_COLOR)),
+                InvestmentEntryKind::Contribution => {
+                    ("Contribution", Style::default().fg(Color::LightGreen))
+                }
+                InvestmentEntryKind::Withdrawal => {
+                    ("Withdrawal", Style::default().fg(Color::LightRed))
+                }
+            };
+
+            Row::new(vec![
+                Cell::from(entry.date.format("%Y-%m-%d").to_string()),
+                Cell::from(label).style(style),
+                Cell::from(right(format_amount(&entry.amount))).style(style),
+                Cell::from(entry.note.clone()).style(Style::default().fg(Color::DarkGray)),
+            ])
+        })
+        .collect();
+
+    let header = Row::new(vec![
+        Cell::from("Date"),
+        Cell::from("Entry"),
+        Cell::from(right("Amount".to_string())),
+        Cell::from("Note"),
+    ])
+    .style(
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    );
+
+    let widths = [
+        Constraint::Length(11),
+        Constraint::Length(13),
+        Constraint::Length(12),
+        Constraint::Min(3),
+    ];
+
+    let table = Table::new(rows, widths)
+        .header(header)
+        .block(panel(Line::from(heading("History")), Borders::TOP))
+        .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
+        .highlight_symbol("> ");
+
+    f.render_stateful_widget(table, area, &mut app.investment_entry_table_state);
+}
+
+fn render_yearly_table(f: &mut Frame, app: &App, area: Rect) {
+    let breakdown = app
+        .portfolio
+        .yearly_breakdown(app.investment_detail_id, app.show_archived_investments);
+
+    let rows: Vec<Row> = breakdown
+        .iter()
+        .rev()
+        .map(|(year, invested, growth, ret)| {
+            Row::new(vec![
+                Cell::from(year.to_string()).style(Style::default().fg(Color::Magenta)),
+                Cell::from(right(format_amount(invested)))
+                    .style(Style::default().fg(INVESTED_COLOR)),
+                Cell::from(right(format_signed_amount(growth))).style(gain_style(*growth)),
+                Cell::from(right(format_percent(*ret))).style(gain_style(*growth)),
+            ])
+        })
+        .collect();
+
+    let header = Row::new(vec![
+        Cell::from("Year"),
+        Cell::from(right("Invested".to_string())),
+        Cell::from(right("Growth".to_string())),
+        Cell::from(right("Return".to_string())),
+    ])
+    .style(
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    );
+
+    let widths = [
+        Constraint::Length(6),
+        Constraint::Min(8),
+        Constraint::Min(8),
+        Constraint::Length(6),
+    ];
+
+    let table = Table::new(rows, widths).header(header).block(panel(
+        Line::from(heading("By Year")),
+        Borders::TOP | Borders::LEFT,
+    ));
+
+    f.render_widget(table, area);
+}
+
+pub fn render_investment_account_editor(f: &mut Frame, app: &App, area: Rect) {
+    let popup_area = centered_rect(60, 80, area);
+    f.render_widget(Clear, popup_area);
+
+    let title = if app.editing_investment_account_id.is_some() {
+        " Edit Investment Account "
+    } else {
+        " Add Investment Account "
+    };
+
+    render_field_form(
+        f,
+        &app.investment_account_fields,
+        app.investment_account_cursor,
+        popup_area,
+        title,
+        Some(" [Esc] Cancel, [Enter] Save "),
+        if app.investment_opening_fields_active() {
+            |_| None
+        } else {
+            |field| {
+                matches!(
+                    field,
+                    crate::app::fields::InvestmentAccountField::OpeningValue
+                        | crate::app::fields::InvestmentAccountField::OpeningInvested
+                        | crate::app::fields::InvestmentAccountField::OpeningDate
+                )
+                .then_some("Edit the account's entries instead")
+            }
+        },
+    );
+}
+
+pub fn render_investment_entry_editor(f: &mut Frame, app: &App, area: Rect) {
+    let popup_area = centered_rect(60, 60, area);
+    f.render_widget(Clear, popup_area);
+
+    let account = app
+        .active_investment_account_id()
+        .and_then(|id| app.portfolio.account(id))
+        .map(|account| account.name.as_str())
+        .unwrap_or("Investment");
+    let title = if app.editing_investment_entry_id.is_some() {
+        format!(" Edit Entry | {} ", account)
+    } else {
+        format!(" Record Entry | {} ", account)
+    };
+
+    render_field_form(
+        f,
+        &app.investment_entry_fields,
+        app.investment_entry_cursor,
+        popup_area,
+        &title,
+        Some(" [Esc] Cancel, [Enter] Toggle/Save "),
+        |_| None,
+    );
+}
+
+fn right(text: String) -> Line<'static> {
+    Line::from(text).alignment(Alignment::Right)
+}

--- a/src/ui/investments.rs
+++ b/src/ui/investments.rs
@@ -118,11 +118,11 @@ fn render_empty_state(f: &mut Frame, area: Rect) {
         Line::from("that you contributed, so growth is measured from the right place."),
         Line::from(""),
         Line::from(Span::styled(
-            "Then record a valuation ('v') whenever you check on it, and a contribution",
+            "Then press 'v' whenever you check on it to record what it is worth, and open",
             Style::default().fg(Color::DarkGray),
         )),
         Line::from(Span::styled(
-            "or withdrawal ('n') whenever money moves. Growth is worked out from those.",
+            "it with Enter to add contributions and withdrawals. Growth comes from those.",
             Style::default().fg(Color::DarkGray),
         )),
     ])

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3,10 +3,12 @@ pub mod category_manager;
 pub mod category_summary;
 pub mod dialog;
 pub mod filter;
+pub mod form;
 pub mod fuzzy_search;
 pub mod help;
 pub mod help_popup;
 pub mod helpers;
+pub mod investments;
 pub mod ledger_manager;
 pub mod recurring;
 pub mod settings;
@@ -19,6 +21,16 @@ pub mod update_popup;
 
 use crate::app::state::{App, AppMode};
 use ratatui::Frame;
+use ratatui::layout::Rect;
+
+/// Whichever investments screen a popup was opened over.
+fn render_investment_background(f: &mut Frame, app: &mut App, area: Rect) {
+    if app.investment_detail_id.is_some() {
+        investments::render_investment_detail(f, app, area);
+    } else {
+        investments::render_investments_view(f, app, area);
+    }
+}
 
 pub(crate) fn ui(f: &mut Frame, app: &mut App) {
     // Determine the effective mode for rendering the background (if in help mode)
@@ -62,6 +74,11 @@ pub(crate) fn ui(f: &mut Frame, app: &mut App) {
             | AppMode::LedgerManager
             | AppMode::LedgerEditor
             | AppMode::ConfirmLedgerDelete
+            | AppMode::Investments
+            | AppMode::InvestmentDetail
+            | AppMode::InvestmentAccountEditor
+            | AppMode::InvestmentEntryEditor
+            | AppMode::ConfirmInvestmentDelete
     ) {
         0
     } else {
@@ -158,6 +175,21 @@ pub(crate) fn ui(f: &mut Frame, app: &mut App) {
         AppMode::ConfirmLedgerDelete => {
             ledger_manager::render_ledger_manager(f, app, main_area);
             dialog::render_confirmation_dialog(f, &app.ledger_delete_prompt, main_area);
+        }
+        AppMode::Investments | AppMode::InvestmentDetail => {
+            render_investment_background(f, app, main_area);
+        }
+        AppMode::InvestmentAccountEditor => {
+            render_investment_background(f, app, main_area);
+            investments::render_investment_account_editor(f, app, main_area);
+        }
+        AppMode::InvestmentEntryEditor => {
+            render_investment_background(f, app, main_area);
+            investments::render_investment_entry_editor(f, app, main_area);
+        }
+        AppMode::ConfirmInvestmentDelete => {
+            render_investment_background(f, app, main_area);
+            dialog::render_confirmation_dialog(f, &app.investment_delete_prompt, main_area);
         }
         AppMode::RecurringSettings => {
             recurring::render_recurring_settings(f, app, main_area);

--- a/src/ui/transaction_form.rs
+++ b/src/ui/transaction_form.rs
@@ -1,98 +1,21 @@
-use crate::app::fields::{FieldKey, FieldKind};
-use crate::app::state::App;
+use crate::app::state::{App, AppMode};
+use crate::ui::form::render_field_form;
 use ratatui::prelude::*;
-use ratatui::widgets::*;
 
 pub fn render_transaction_form(f: &mut Frame, app: &App, area: Rect) {
-    let focused_field = app.add_edit_fields.focused();
-    let input_widgets: Vec<_> = app
-        .add_edit_fields
-        .iter()
-        .map(|(field, text)| {
-            let is_focused = field == focused_field;
-            let title = format!("{} {}", field.label(), field.hint())
-                .trim_end()
-                .to_string();
-            let content = if field.kind() == FieldKind::Toggle {
-                Span::styled(
-                    format!(" < {} > ", text),
-                    Style::default().fg(Color::White).bold(),
-                )
-            } else {
-                Span::raw(text.as_str())
-            };
-            Paragraph::new(content)
-                .style(Style::default().fg(Color::White))
-                .block(
-                    Block::default()
-                        .borders(Borders::ALL)
-                        .title(title)
-                        .border_style(if is_focused {
-                            Style::default().fg(Color::Yellow)
-                        } else {
-                            Style::default()
-                        }),
-                )
-        })
-        .collect();
-
-    // Vertical scroll logic for small terminal heights
-    let margin = 1;
-    let field_height = 3;
-    let total_fields = input_widgets.len();
-    let available_height = area.height.saturating_sub(margin * 2);
-    let max_visible_fields = ((available_height / field_height) as usize)
-        .max(1)
-        .min(total_fields);
-    let scroll_offset = focused_field
-        .index()
-        .saturating_sub(max_visible_fields - 1)
-        .min(total_fields - max_visible_fields);
-
-    let mut constraints = Vec::with_capacity(max_visible_fields + 1);
-    for _ in 0..max_visible_fields {
-        constraints.push(Constraint::Length(field_height));
-    }
-    constraints.push(Constraint::Min(0));
-    let form_chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .margin(margin)
-        .constraints(constraints)
-        .split(area);
-
-    // Render only the visible input widgets
-    for (idx, widget) in input_widgets
-        .iter()
-        .enumerate()
-        .skip(scroll_offset)
-        .take(max_visible_fields)
-    {
-        let chunk_index = idx - scroll_offset;
-        f.render_widget(widget.clone(), form_chunks[chunk_index]);
-    }
-
-    let form_title_text = if app.mode == crate::app::state::AppMode::Editing {
+    let title = if app.mode == AppMode::Editing {
         "Edit Transaction"
     } else {
         "Add New Transaction"
     };
-    let form_block = Block::default()
-        .title(form_title_text)
-        .borders(Borders::ALL);
-    f.render_widget(form_block, area);
 
-    // Set cursor position for editable text fields, adjusting for scrolling
-    if focused_field.kind().is_editable() {
-        let field_idx = focused_field.index();
-        let text = &app.add_edit_fields[focused_field];
-        let cursor_byte_idx = app.add_edit_cursor.min(text.len());
-        let visual_cursor = text[..cursor_byte_idx].chars().count() as u16;
-
-        if field_idx >= scroll_offset && field_idx < scroll_offset + max_visible_fields {
-            let visible_idx = field_idx - scroll_offset;
-            if let Some(chunk) = form_chunks.get(visible_idx) {
-                f.set_cursor_position(Position::new(chunk.x + visual_cursor + 1, chunk.y + 1));
-            }
-        }
-    }
+    render_field_form(
+        f,
+        &app.add_edit_fields,
+        app.add_edit_cursor,
+        area,
+        title,
+        None,
+        |_| None,
+    );
 }

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -260,3 +260,13 @@ pub fn strip_path_quotes(path: &str) -> String {
 
     result
 }
+
+/// Like [`validate_amount_string`] but admits zero, for values that can legitimately be nothing
+/// (an investment account you have sold out of is worth 0, not "invalid").
+pub fn validate_non_negative_amount_string(amount_str: &str) -> Result<Decimal, String> {
+    match amount_str.parse::<Decimal>() {
+        Ok(amount) if amount >= Decimal::ZERO => Ok(amount),
+        Ok(_) => Err("Amount cannot be negative".to_string()),
+        Err(_) => Err("Invalid amount format".to_string()),
+    }
+}


### PR DESCRIPTION
Adds an Investments view (i from the main list) for manually tracking investment accounts. No live prices or bank connections. You record what you see when you check an account, and the app figures out the rest.

### How it works

You never type in a gain. You record two things:

- a valuation ("this is worth $62,410 today")
- a contribution or withdrawal (money moving in or out)

Growth is what's left over: the change in value with your own money taken back out. So paying into an account can't make your returns look better than they were.

### What's in it

- Overview with value, cost basis, gain and ROI per account, plus a chart of total value drawn above cumulative contributions. The gap between the lines is your growth.
- Detail view (Enter) with full entry history and a year by year breakdown of what you put in against what it earned.
- Opening positions so setting up an account you already hold doesn't report the whole balance as a day one gain.
- Staleness flags on valuations older than 30 days, since your total is a sum of marks taken on different days.
- Archiving (A) to keep a closed account's history out of the totals.

Behaviour matches the rest of the app. a/e/d act on whatever the rows on screen are, accounts on the list and entries inside one. v records a valuation dated today with the cursor already in the amount. ←/→ move the chart window.


Also pulled the shared form layout out into ui/form.rs, which both existing forms now use too. That dropped 179 lines from transaction_form.rs and category_manager.rs.