### PR TITLE
Fix entries getting cut off after filtering

### DIFF
--- a/src/ui/backup.rs
+++ b/src/ui/backup.rs
@@ -1,5 +1,6 @@
 use crate::app::state::App;
 use crate::db::backup::{BackupEntry, backups_dir};
+use crate::ui::helpers::clamp_table_scroll;
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 
@@ -64,6 +65,7 @@ pub fn render_backup_manager(f: &mut Frame, app: &mut App, area: Rect) {
     .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
     .highlight_symbol("> ");
 
+    clamp_table_scroll(&mut app.backup_table_state, app.backup_entries.len(), area);
     f.render_stateful_widget(table, area, &mut app.backup_table_state);
 }
 

--- a/src/ui/budget.rs
+++ b/src/ui/budget.rs
@@ -1,6 +1,8 @@
 use crate::app::state::{App, BudgetCategoryComparison, BudgetEditTarget};
 use crate::model::{BudgetEditScope, BudgetMonth};
-use crate::ui::helpers::{format_amount, format_signed_amount, month_to_color, month_to_short_str};
+use crate::ui::helpers::{
+    clamp_table_scroll, format_amount, format_signed_amount, month_to_color, month_to_short_str,
+};
 use ratatui::prelude::*;
 use ratatui::text::Line;
 use ratatui::widgets::{
@@ -601,6 +603,8 @@ pub fn render_budget_view(f: &mut Frame, app: &mut App, area: Rect) {
         comparisons.iter().map(comparison_row).collect()
     };
 
+    let row_count = rows.len();
+
     let bottom_chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Percentage(62), Constraint::Percentage(38)])
@@ -644,6 +648,7 @@ pub fn render_budget_view(f: &mut Frame, app: &mut App, area: Rect) {
     ))
     .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
     .highlight_symbol(" > ");
+    clamp_table_scroll(&mut app.budget_table_state, row_count, bottom_chunks[0]);
     f.render_stateful_widget(table, bottom_chunks[0], &mut app.budget_table_state);
 
     let detail_chunks = Layout::default()

--- a/src/ui/category_manager.rs
+++ b/src/ui/category_manager.rs
@@ -2,6 +2,7 @@ use crate::app::fields::CategoryEditField;
 use crate::app::state::App;
 use crate::model::{CategorySortColumn, SortOrder};
 use crate::ui::form::render_field_form;
+use crate::ui::helpers::clamp_table_scroll;
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 
@@ -115,6 +116,11 @@ pub fn render_category_catalog(f: &mut Frame, app: &mut App, area: Rect) {
     .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
     .highlight_symbol("> ");
 
+    clamp_table_scroll(
+        &mut app.category_table_state,
+        app.filtered_category_indices.len(),
+        area,
+    );
     f.render_stateful_widget(table, area, &mut app.category_table_state);
 }
 

--- a/src/ui/category_summary.rs
+++ b/src/ui/category_summary.rs
@@ -1,6 +1,6 @@
 use crate::app::state::{App, CategorySummaryItem};
 use crate::model::{MonthlySummary, TransactionType};
-use crate::ui::helpers::{format_amount, month_to_short_str};
+use crate::ui::helpers::{clamp_table_scroll, format_amount, month_to_short_str};
 use ratatui::prelude::*;
 use ratatui::text::Line;
 use ratatui::widgets::*;
@@ -351,6 +351,7 @@ pub fn render_category_summary_view(f: &mut Frame, app: &mut App, area: Rect) {
         Line::from(title_spans)
     };
 
+    let item_count = items.len();
     let table = Table::new(
         rows,
         [
@@ -367,6 +368,7 @@ pub fn render_category_summary_view(f: &mut Frame, app: &mut App, area: Rect) {
     .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
     .highlight_symbol(" > ");
 
+    clamp_table_scroll(&mut app.category_summary_table_state, item_count, list_area);
     f.render_stateful_widget(table, list_area, &mut app.category_summary_table_state);
 
     let footer_table = Table::new(

--- a/src/ui/dialog.rs
+++ b/src/ui/dialog.rs
@@ -1,5 +1,5 @@
 use crate::app::state::App;
-use crate::ui::helpers::centered_rect;
+use crate::ui::helpers::{centered_rect, clamp_list_scroll};
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 
@@ -35,6 +35,7 @@ pub fn render_selection_popup(f: &mut Frame, app: &mut App, area: Rect) {
         .map(|i| ListItem::new(i.as_str()).style(Style::default().fg(Color::White)))
         .collect();
 
+    let item_count = items.len();
     let list = List::new(items)
         .block(Block::default().title(popup_title).borders(Borders::ALL))
         .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
@@ -43,5 +44,6 @@ pub fn render_selection_popup(f: &mut Frame, app: &mut App, area: Rect) {
     let popup_area = centered_rect(60, 50, area);
 
     f.render_widget(Clear, popup_area);
+    clamp_list_scroll(&mut app.selection_list_state, item_count, popup_area);
     f.render_stateful_widget(list, popup_area, &mut app.selection_list_state);
 }

--- a/src/ui/fuzzy_search.rs
+++ b/src/ui/fuzzy_search.rs
@@ -1,5 +1,5 @@
 use crate::app::state::App;
-use crate::ui::helpers::centered_rect;
+use crate::ui::helpers::{centered_rect, clamp_list_scroll};
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 
@@ -35,6 +35,7 @@ pub fn render_fuzzy_search(f: &mut Frame, app: &mut App, area: Rect) {
         .map(|i| ListItem::new(i.as_str()).style(Style::default().fg(Color::White)))
         .collect();
 
+    let item_count = items.len();
     let list = List::new(items)
         .block(
             Block::default()
@@ -44,5 +45,6 @@ pub fn render_fuzzy_search(f: &mut Frame, app: &mut App, area: Rect) {
         .highlight_style(Style::default().add_modifier(Modifier::REVERSED))
         .highlight_symbol("> ");
 
+    clamp_list_scroll(&mut app.selection_list_state, item_count, chunks[1]);
     f.render_stateful_widget(list, chunks[1], &mut app.selection_list_state);
 }

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -1,5 +1,6 @@
 use crate::app::help::get_help_for_mode;
 use crate::app::state::{App, AppMode};
+use crate::ui::helpers::clamp_table_scroll;
 use ratatui::{prelude::*, widgets::*};
 
 pub fn render_keybindings_popup(f: &mut Frame, app: &mut App, area: Rect) {
@@ -66,6 +67,7 @@ pub fn render_keybindings_popup(f: &mut Frame, app: &mut App, area: Rect) {
     )
     .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED));
 
+    clamp_table_scroll(&mut app.help_table_state, total_rows, popup_area);
     // Render the stateful widget
     f.render_stateful_widget(table, popup_area, &mut app.help_table_state);
 

--- a/src/ui/helpers.rs
+++ b/src/ui/helpers.rs
@@ -1,6 +1,22 @@
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::Color;
+use ratatui::widgets::{ListState, TableState};
 use rust_decimal::{Decimal, RoundingStrategy};
+
+/// Ratatui clamps a stale offset to `len - 1` and only ever scrolls down, so filtering 400 rows
+/// to 3 leaves one row on screen and two left hidden above it. Ignoring borders and the header is
+/// fine, since this only shrinks the offset and the render pass scrolls back down as needed.
+fn clamped_offset(offset: usize, row_count: usize, area: Rect) -> usize {
+    offset.min(row_count.saturating_sub(area.height as usize))
+}
+
+pub fn clamp_table_scroll(state: &mut TableState, row_count: usize, area: Rect) {
+    *state.offset_mut() = clamped_offset(state.offset(), row_count, area);
+}
+
+pub fn clamp_list_scroll(state: &mut ListState, item_count: usize, area: Rect) {
+    *state.offset_mut() = clamped_offset(state.offset(), item_count, area);
+}
 
 pub fn format_amount(amount: &Decimal) -> String {
     // Rounding via f64 would go off the binary approximation, not the stored decimal digits.

--- a/src/ui/investments.rs
+++ b/src/ui/investments.rs
@@ -2,7 +2,7 @@ use crate::app::investments::STALE_VALUATION_DAYS;
 use crate::app::state::App;
 use crate::model::{InvestmentEntryKind, InvestmentRange};
 use crate::ui::form::render_field_form;
-use crate::ui::helpers::{centered_rect, format_amount, format_signed_amount};
+use crate::ui::helpers::{centered_rect, clamp_table_scroll, format_amount, format_signed_amount};
 use chrono::NaiveDate;
 use ratatui::prelude::*;
 use ratatui::widgets::{
@@ -490,12 +490,14 @@ fn render_accounts_table(f: &mut Frame, app: &mut App, area: Rect) {
         ));
     }
 
+    let row_count = rows.len();
     let table = Table::new(rows, widths)
         .header(header)
         .block(panel(Line::from(title), Borders::TOP))
         .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
         .highlight_symbol("> ");
 
+    clamp_table_scroll(&mut app.investment_table_state, row_count, area);
     f.render_stateful_widget(table, area, &mut app.investment_table_state);
 }
 
@@ -551,12 +553,14 @@ fn render_entries_table(f: &mut Frame, app: &mut App, area: Rect) {
         Constraint::Min(3),
     ];
 
+    let row_count = rows.len();
     let table = Table::new(rows, widths)
         .header(header)
         .block(panel(Line::from(heading("History")), Borders::TOP))
         .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
         .highlight_symbol("> ");
 
+    clamp_table_scroll(&mut app.investment_entry_table_state, row_count, area);
     f.render_stateful_widget(table, area, &mut app.investment_entry_table_state);
 }
 

--- a/src/ui/ledger_manager.rs
+++ b/src/ui/ledger_manager.rs
@@ -1,4 +1,5 @@
 use crate::app::state::App;
+use crate::ui::helpers::clamp_table_scroll;
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 
@@ -37,6 +38,7 @@ pub fn render_ledger_manager(f: &mut Frame, app: &mut App, area: Rect) {
         .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
         .highlight_symbol("> ");
 
+    clamp_table_scroll(&mut app.ledger_table_state, app.ledgers.len(), area);
     f.render_stateful_widget(table, area, &mut app.ledger_table_state);
 }
 

--- a/src/ui/transaction_table.rs
+++ b/src/ui/transaction_table.rs
@@ -1,6 +1,6 @@
 use crate::app::state::App;
 use crate::model::{DATE_FORMAT, SortColumn, SortOrder, TransactionType};
-use crate::ui::helpers::{format_amount, format_hours};
+use crate::ui::helpers::{clamp_table_scroll, format_amount, format_hours};
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 pub fn render_transaction_table(f: &mut Frame, app: &mut App, area: Rect) {
@@ -147,5 +147,6 @@ pub fn render_transaction_table(f: &mut Frame, app: &mut App, area: Rect) {
     .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED))
     .highlight_symbol(" > ");
 
+    clamp_table_scroll(&mut app.table_state, app.filtered_indices.len(), area);
     f.render_stateful_widget(table, area, &mut app.table_state);
 }


### PR DESCRIPTION
Adjusts scroll offsets across tables and lists so entries stay visible when there’s room.

Fixes #111.